### PR TITLE
Use multistage dockerfile in CI

### DIFF
--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -33,23 +33,10 @@ function install_deps() {
 
   # Login to quay.io
   docker login -u "${QUAY_ECLIPSE_CHE_USERNAME}" -p "${QUAY_ECLIPSE_CHE_PASSWORD}" "${REGISTRY}"
-  setup_golang
-}
-
-# Perform necessary GOPATH setup to make project buildable
-function setup_golang() {
-  go version
-  mkdir -p "$HOME"/go "$HOME"/go/src "$HOME"/go/bin "$HOME"/go/pkg
-  export GOPATH=$HOME/go
-  export PATH=${GOPATH}/bin:$PATH
-  mkdir -p "${GOPATH}"/src/github.com/che-incubator
-  cp -r "$HOME"/payload "${GOPATH}"/src/github.com/che-incubator/kubernetes-image-puller
-  cd "${GOPATH}"/src/github.com/che-incubator/kubernetes-image-puller || exit
 }
 
 function build() {
   LOCAL_IMAGE_NAME="kubernetes-image-puller"
-  make build
   docker build -t ${LOCAL_IMAGE_NAME} -f ./docker/Dockerfile.centos .
 }
 

--- a/docker/Dockerfile.centos
+++ b/docker/Dockerfile.centos
@@ -1,8 +1,15 @@
+FROM golang:1.13 AS build
+
+RUN mkdir -p $GOPATH/src/github.com/che-incubator/kubernetes-image-puller
+ADD . $GOPATH/src/github.com/che-incubator/kubernetes-image-puller
+WORKDIR $GOPATH/src/github.com/che-incubator/kubernetes-image-puller
+RUN ["make", "build"]
+
 FROM registry.centos.org/centos:7
 
 RUN yum update -y -d 1 \
     && yum clean all -y \
     && rm -rf /var/cache/yum
 
-COPY "./bin/kubernetes-image-puller" "/"
+COPY --from=build /go/src/github.com/che-incubator/kubernetes-image-puller/bin/kubernetes-image-puller /
 CMD ["/kubernetes-image-puller"]


### PR DESCRIPTION
Change to building from a multistage dockerfile because the CI has a problem pulling dependencies with an old version of git

Signed-off-by: Tom George <tgeorge@redhat.com>