### PR TITLE
Move Go build into docker build for reproducability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ test:
 docker:
 	docker build -t ${DOCKERIMAGE_NAME}:${DOCKERIMAGE_TAG} -f ./docker/Dockerfile .
 
+docker-dev: build
+	docker build -t ${DOCKERIMAGE_NAME}:${DOCKERIMAGE_TAG} -f ./docker/dev.Dockerfile .
+
 local-setup:
 	oc process -f ./deploy/serviceaccount.yaml | oc apply -f -
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ lint:
 test:
 	go test -v ./cfg... ./pkg... ./utils...
 
-docker: build
+docker:
 	docker build -t ${DOCKERIMAGE_NAME}:${DOCKERIMAGE_TAG} -f ./docker/Dockerfile .
 
 local-setup:

--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -34,7 +34,6 @@ function install_deps() {
 
 function build() {
   LOCAL_IMAGE_NAME="kubernetes-image-puller"
-  docker run -v $(pwd):/go/src/github.com/che-incubator/kubernetes-image-puller -w /go/src/github.com/che-incubator/kubernetes-image-puller golang:1.13 make build
   docker build -t ${LOCAL_IMAGE_NAME} -f ./docker/centos.Dockerfile .
 }
 

--- a/dev-guide.adoc
+++ b/dev-guide.adoc
@@ -45,13 +45,21 @@ The included Makefile supports
 | docker
 | Build a docker container (see below)
 
+| docker-dev
+| Build a docker container without multi-stage builds, for compatibility (see below).
+
 | clean
 | Remove build artifacts.
 |===
 
 == The docker build
 
-Currently, the docker build is set up to simply copy the build binary into a distroless image; this was done initially since the version of docker that shipped with minishift did not support multi-stage builds. This means that a local binary has to be created before the docker image is built. (This is a TODO for the repo).
+The docker build, by default, will use a multi-stage build that
+1. Grabs all dependencies defined in `go.mod` (`--target=dependencies`)
+2. Builds the Go project (`--target=builder`)
+3. Copies the binary into a clean image
+
+Since multi-stage builds are not supported by all versions of docker, there is also a simpler dockerfile (see `./docker/dev.Dockerfile`) that copies an already-built binary into a distroless image. This build can be invoked using the `docker-dev` target in the Makefile.
 
 == Outstanding issues
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,20 @@
+FROM golang:1.13.8 AS dependencies
+
+WORKDIR /kubernetes-image-puller
+
+# Populate the module cache based on the go.{mod,sum} files.
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+FROM dependencies AS builder
+
+COPY . .
+# RUN go test -v ./cfg... ./pkg... ./utils... \
+#     && GOOS=linux go build -v -o ./bin/${BINARY_NAME} ./cmd/main.go
+RUN make build
+
+
 FROM gcr.io/distroless/base
-COPY "./bin/kubernetes-image-puller" "/"
+COPY --from=builder "/kubernetes-image-puller/bin/kubernetes-image-puller" "/"
 CMD ["/kubernetes-image-puller"]

--- a/docker/centos.Dockerfile
+++ b/docker/centos.Dockerfile
@@ -1,8 +1,22 @@
+FROM golang:1.13.8 AS dependencies
+
+WORKDIR /kubernetes-image-puller
+
+# Populate the module cache based on the go.{mod,sum} files.
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+FROM dependencies AS builder
+
+COPY . .
+RUN make build
+
 FROM registry.centos.org/centos:7
 
 RUN yum update -y -d 1 \
     && yum clean all -y \
     && rm -rf /var/cache/yum
 
-COPY "./bin/kubernetes-image-puller" "/"
+COPY --from=builder "/kubernetes-image-puller/bin/kubernetes-image-puller" "/"
 CMD ["/kubernetes-image-puller"]

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/distroless/base
+COPY "./bin/kubernetes-image-puller" "/"
+CMD ["/kubernetes-image-puller"]


### PR DESCRIPTION
### What does this PR do?

- Add stages to dockerfiles to include the binary build as an earlier step. 
- Add `dev.Dockerfile` to support the old development use-case (since `minishift docker-env` does not support multi-stage builds.
- Update CI, Makefile to support changes and document.