### PR TITLE
feat(sleep): Provide a self-contained sleep binary that can be reused in scratch images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,13 @@ all: build docker
 
 build: test
 	GOOS=linux go build -v -o ./bin/${BINARY_NAME} ./cmd/main.go
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo -o ./bin/sleep ./sleep/sleep.go
 
 lint:
 	golangci-lint run -v
 
 test:
-	go test -v ./cfg... ./pkg... ./utils...
+	go test -v ./cfg... ./pkg... ./sleep... ./utils...
 
 docker:
 	docker build -t ${DOCKERIMAGE_NAME}:${DOCKERIMAGE_TAG} -f ./docker/Dockerfile .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,6 +50,7 @@ COPY --from=builder /etc/passwd /etc/passwd
 
 USER appuser
 COPY --from=builder /kubernetes-image-puller/bin/kubernetes-image-puller /
+COPY --from=builder /kubernetes-image-puller/bin/sleep /bin/sleep
 # NOTE: To use this container, need a configmap. See example at ./deploy/openshift/configmap.yaml
 # See also https://github.com/che-incubator/kubernetes-image-puller#configuration
 CMD ["/kubernetes-image-puller"]

--- a/docker/centos.Dockerfile
+++ b/docker/centos.Dockerfile
@@ -19,4 +19,5 @@ RUN yum update -y -d 1 \
     && rm -rf /var/cache/yum
 
 COPY --from=builder "/kubernetes-image-puller/bin/kubernetes-image-puller" "/"
+COPY --from=builder /kubernetes-image-puller/bin/sleep /bin/sleep
 CMD ["/kubernetes-image-puller"]

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,3 +1,4 @@
 FROM gcr.io/distroless/base
 COPY "./bin/kubernetes-image-puller" "/"
+COPY ./bin/sleep /bin/sleep
 CMD ["/kubernetes-image-puller"]

--- a/sleep/sleep.go
+++ b/sleep/sleep.go
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+func displayUsage(out io.Writer) int {
+	fmt.Fprintf(out, "Usage: %s <duration>\n", os.Args[0])
+	fmt.Fprintln(out, "See https://pkg.go.dev/time#ParseDuration")
+	return -1
+}
+
+func main() {
+	exitCode := entryPoint(os.Stderr)
+	if exitCode != 0 {
+		os.Exit(exitCode)
+	}
+}
+
+func entryPoint(out io.Writer) int {
+	if len(os.Args) != 2 {
+		return displayUsage(out)
+	}
+	duration, err := time.ParseDuration(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(out, "Invalid duration: %s\n", err)
+		return displayUsage(out)
+	}
+	time.Sleep(duration)
+	return 0
+}

--- a/sleep/sleep_test.go
+++ b/sleep/sleep_test.go
@@ -1,0 +1,57 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"testing"
+)
+
+func TestArguments(T *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	cases := []struct {
+		Name           string
+		Args           []string
+		ExpectedExit   int
+		ExpectedOutput string
+	}{
+		{"valid second duration", []string{"1s"}, 0, ""},
+		{"valid ns duration", []string{"1000ns"}, 0, ""},
+		{"invalid day duration", []string{"10d"}, -1, "Invalid duration: time: unknown unit \"d\" in duration \"10d\"\nUsage: invalid day duration <duration>\nSee https://pkg.go.dev/time#ParseDuration\n"},
+		{"too many args", []string{"a", "b"}, -1, "Usage: too many args <duration>\nSee https://pkg.go.dev/time#ParseDuration\n"},
+	}
+	for _, tc := range cases {
+		flag.CommandLine = flag.NewFlagSet(tc.Name, flag.ExitOnError)
+		os.Args = append([]string{tc.Name}, tc.Args...)
+		var buf bytes.Buffer
+		actualExit := entryPoint(&buf)
+		if tc.ExpectedExit != actualExit {
+			T.Errorf("Wrong exit code for args: %v, expected: %v, got: %v",
+				tc.Args, tc.ExpectedExit, actualExit)
+		}
+
+		actualOutput := buf.String()
+		if tc.ExpectedOutput != actualOutput {
+			T.Errorf("Wrong output for args: %v, expected %v, got: %v",
+				tc.Args, tc.ExpectedOutput, actualOutput)
+		}
+
+		// check main entrypoint
+		flag.CommandLine = flag.NewFlagSet("100ms", 0)
+		os.Args = append([]string{"100ms"}, "100ms")
+		main()
+	}
+}

--- a/utils/clusterutils.go
+++ b/utils/clusterutils.go
@@ -243,7 +243,7 @@ func getContainers() []corev1.Container {
 			Name:            name,
 			Image:           image,
 			Command:         []string{"sleep"},
-			Args:            []string{"30d"},
+			Args:            []string{"720h"},
 			Resources:       cachedImageResources,
 			ImagePullPolicy: corev1.PullAlways,
 		}

--- a/utils/clusterutils_test.go
+++ b/utils/clusterutils_test.go
@@ -26,7 +26,7 @@ var (
 	}
 
 	defaultCommand = []string{"sleep"}
-	defaultArgs    = []string{"30d"}
+	defaultArgs    = []string{"720h"}
 )
 
 // This is the only function that does not require a kubernetes client.  The rest of the tests are in ./e2e


### PR DESCRIPTION
Add tests of the sleep utility
Also change 30d to 720h so that it's matching duration time library of go that does not handle `d`/days

store the binary as /bin/sleep

Related to https://github.com/eclipse/che/issues/19755