### PR TITLE
Change namespace env variable from config map

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The following values can be set:
 | `CACHING_MEMORY_LIMIT` | The value of `CACHING_MEMORY_LIMIT` to be set in the ConfigMap | `"20Mi"` |
 | `CACHING_CPU_REQUEST` | The value of `CACHING_CPU_REQUEST` to be set in the ConfigMap | `.05` |
 | `CACHING_CPU_LIMIT` | The value of `CACHING_CPU_LIMIT` to be set in the ConfigMap | `.2` |
+| `NAMESPACE` | The value of `NAMESPACE` to be set in the ConfigMap | `k8s-image-puller` |
 | `NODE_SELECTOR` | The value of `NODE_SELECTOR` to be set in the ConfigMap | `"{}"` |
 | `IMAGE_PULL_SECRETS` | The value of `IMAGE_PULL_SECRETS`       | `""` |
 | `AFFINITY` | The value of `AFFINITY` to be set in the ConfigMap | `"{}"` |

--- a/deploy/openshift/configmap.yaml
+++ b/deploy/openshift/configmap.yaml
@@ -33,7 +33,7 @@ parameters:
 - name: CACHING_INTERVAL_HOURS
   value: "1"
 - name: NAMESPACE
-  value: "kubernetes-image-puller"
+  value: "k8s-image-puller"
 - name: CACHING_MEMORY_REQUEST
   value: "10Mi"
 - name: CACHING_MEMORY_LIMIT


### PR DESCRIPTION
Fixes https://github.com/eclipse/che/issues/19969.

Changed `kubernetes-` to `k8s-` since a project name prefixed with `kubernetes-` is reserved by OpenShift (https://github.com/openshift/origin/pull/13673/commits/d654a6dfe999e0cd1e27ade6afefc6163b15011f).

Signed-off-by: David Kwon <dakwon@redhat.com>