### PR TITLE
(feat) Support scratch images by using sleep binary from volumeMount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINARY_NAME=kubernetes-image-puller
 DOCKERIMAGE_NAME=kubernetes-image-puller
-DOCKERIMAGE_TAG=latest
+DOCKERIMAGE_TAG=next
 
 all: build docker
 

--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ The following values can be set:
 | Value                            | Usage                                                        | Default                                               |
 | -------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------- |
 | `deploymentName`                 | The value of `DAEMONSET_NAME` to be set in the ConfigMap, as well as the name of the deployment     | `kubernetes-image-puller`                             |
-| `image.repository`               | The repository to pull the image from                        | `quay.io/eclpise/kubernetes-image-puller`             |
+| `image.repository`               | The repository to pull the image from                        | `quay.io/eclipse/kubernetes-image-puller`             |
 | `image.tag`                      | The image tag to pull                                        | `latest`                                              |
 | `serviceAccount.name`            | The name of the ServiceAccount to create                     | `k8s-image-puller`                                    |
 | `configMap.name`                 | The name of the ConfigMap to create                          | `k8s-image-puller`                                    |
 | `configMap.images`               | The value of `IMAGES` to be set in the ConfigMap             | // TODO create a reasonable set of default containers |
 | `configMap.cachingIntervalHours` | The value of `CACHING_INTERVAL_HOURS` to be set in the ConfigMap | `"1"`                                                 |
-| `configMap.cachingMemoryRequest` | The value of `CACHING_MEMORY_REQUEST` to be set in the ConfigMap | `"10Mi"`                                              |
-| `configMap.cachingMemeryLimit`   | The value of `CACHING_MEMORY_LIMIT` to be set in the ConfigMap | `"20Mi"`                                              |
+| `configMap.cachingMemoryRequest` | The value of `CACHING_MEMORY_REQUEST` to be set in the ConfigMap | `"1Mi"`                                              |
+| `configMap.cachingMemoryLimit`   | The value of `CACHING_MEMORY_LIMIT` to be set in the ConfigMap | `"5Mi"`                                              |
 | `configMap.cachingCpuRequest`    | The value of `CACHING_CPU_REQUEST` to be set in the ConfigMap | `.05`                                                 |
 | `configMap.cachingCpuLimit`      | The value of `CACHING_CPU_LIMIT` to be set in the ConfigMap  | `.2`                                                  |
 | `configMap.nodeSelector`         | The value of `NODE_SELECTOR` to be set in the ConfigMap      | `"{}"`                                                |
@@ -54,13 +54,13 @@ The following values can be set:
 | Parameter | Usage | Default |
 | -- | -- | -- |
 | `SERVICEACCOUNT_NAME`             | Name of service account used by main pod | `k8s-image-puller` |
-| `IMAGE`                           | Name of image used for main pod | `quay.io/eclpise/kubernetes-image-puller` |
+| `IMAGE`                           | Name of image used for main pod | `quay.io/eclipse/kubernetes-image-puller` |
 | `IMAGE_TAG`                       | Tag of image used for main pod | `latest` |
 | `DAEMONSET_NAME` | The value of `DAEMONSET_NAME` to be set in the ConfigMap | `"kubernetes-image-puller"` |
 | `DEPLOYMENT_NAME` | The name of the image puller deployment | `"kubernetes-image-puller"` |
 | `CACHING_INTERVAL_HOURS` | The value of `CACHING_INTERVAL_HOURS` to be set in the ConfigMap | `"1"` |
-| `CACHING_MEMORY_REQUEST` | The value of `CACHING_MEMORY_REQUEST` to be set in the ConfigMap | `"10Mi"` |
-| `CACHING_MEMORY_LIMIT` | The value of `CACHING_MEMORY_LIMIT` to be set in the ConfigMap | `"20Mi"` |
+| `CACHING_MEMORY_REQUEST` | The value of `CACHING_MEMORY_REQUEST` to be set in the ConfigMap | `"1Mi"` |
+| `CACHING_MEMORY_LIMIT` | The value of `CACHING_MEMORY_LIMIT` to be set in the ConfigMap | `"5Mi"` |
 | `CACHING_CPU_REQUEST` | The value of `CACHING_CPU_REQUEST` to be set in the ConfigMap | `.05` |
 | `CACHING_CPU_LIMIT` | The value of `CACHING_CPU_LIMIT` to be set in the ConfigMap | `.2` |
 | `NAMESPACE` | The value of `NAMESPACE` to be set in the ConfigMap | `k8s-image-puller` |
@@ -86,7 +86,7 @@ OpenShift has a notion of [project quotas](https://docs.openshift.com/container-
 (memory/CPU limit) * (number of images) * (number of nodes in cluster)
 ```
 
-For example, running the image puller that caches 5 images on 20 nodes, with a container memory limit of `20Mi`, your namespace would need a quota of `2000Mi`.
+For example, running the image puller that caches 5 images on 20 nodes, with a container memory limit of `5Mi`, your namespace would need a quota of `500Mi`.
 
 #### Installing the image puller
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 ## About
 
-To cache images, Kubernetes Image Puller creates a Daemonset on the desired cluster, which in turn creates a pod on each node in the cluster consisting of a list of containers with command `sleep 30d`. This ensures that all nodes in the cluster have those images cached. We also periodically check the health of the daemonset and re-create it if necessary.
+To cache images, Kubernetes Image Puller creates a Daemonset on the desired cluster, which in turn creates a pod on each node in the cluster consisting of a list of containers with command `sleep 720h`.
+This ensures that all nodes in the cluster have those images cached. The `sleep` binary being used is [golang-based](https://github.com/che-incubator/kubernetes-image-puller/tree/main/sleep) (please see [Scratch Images](#scratch-images)).
+We also periodically check the health of the daemonset and re-create it if necessary.
 
 The application can be deployed via Helm or by processing and applying OpenShift Templates. Also, there is a community supported operator available on the [OperatorHub](https://operatorhub.io/operator/kubernetes-imagepuller-operator).
 
@@ -25,6 +27,7 @@ The config values to be set are:
 | `NODE_SELECTOR` | Node selector applied to pods created by the daemonset       | `'{}'` |
 | `IMAGE_PULL_SECRETS` | List of image pull secrets, in the format `pullsecret1;...` to add to pods created by the DaemonSet. Those secrets need to be in the image puller's namespace and a cluster administrator must create them.       | `""` |
 | `AFFINITY` | Affinity applied to pods created by the daemonset       | `'{}'` |
+| `KIP_IMAGE` | The image puller image to copy the `sleep` binary from | `quay.io/eclipse/kubernetes-image-puller:next` |
 
 ### Configuration - Helm 
 
@@ -34,7 +37,7 @@ The following values can be set:
 | -------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------- |
 | `deploymentName`                 | The value of `DAEMONSET_NAME` to be set in the ConfigMap, as well as the name of the deployment     | `kubernetes-image-puller`                             |
 | `image.repository`               | The repository to pull the image from                        | `quay.io/eclipse/kubernetes-image-puller`             |
-| `image.tag`                      | The image tag to pull                                        | `latest`                                              |
+| `image.tag`                      | The image tag to pull                                        | `next`                                                |
 | `serviceAccount.name`            | The name of the ServiceAccount to create                     | `k8s-image-puller`                                    |
 | `configMap.name`                 | The name of the ConfigMap to create                          | `k8s-image-puller`                                    |
 | `configMap.images`               | The value of `IMAGES` to be set in the ConfigMap             | // TODO create a reasonable set of default containers |
@@ -55,7 +58,7 @@ The following values can be set:
 | -- | -- | -- |
 | `SERVICEACCOUNT_NAME`             | Name of service account used by main pod | `k8s-image-puller` |
 | `IMAGE`                           | Name of image used for main pod | `quay.io/eclipse/kubernetes-image-puller` |
-| `IMAGE_TAG`                       | Tag of image used for main pod | `latest` |
+| `IMAGE_TAG`                       | Tag of image used for main pod | `next` |
 | `DAEMONSET_NAME` | The value of `DAEMONSET_NAME` to be set in the ConfigMap | `"kubernetes-image-puller"` |
 | `DEPLOYMENT_NAME` | The name of the image puller deployment | `"kubernetes-image-puller"` |
 | `CACHING_INTERVAL_HOURS` | The value of `CACHING_INTERVAL_HOURS` to be set in the ConfigMap | `"1"` |
@@ -146,21 +149,11 @@ GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0
 Will start a kind cluster and run the end-to-end tests in `./e2e`.  To remove the cluster after running the tests, pass the `--rm` argument to the script, or run `kind delete cluster --name k8s-image-puller-e2e`.
 
 ## Scratch Images
+The image puller now supports pre-pulling scratch images.
+Previously the image puller was not able to pull scratch images, as they do not contain a `sleep` command.
 
-Normally, the image puller cannot pull scratch images, as they do not contain a `sleep` command.
+However, the daemonset created by the image puller now:
+1. creates an `initContainer` that copies a golang-based `sleep` binary to a common `kip` volume.
+2. creates containers `volumeMounts` set to the `kip` volume, and with `command` set to `/kip/sleep 720h`
 
-But as of [2021-05-06](https://github.com/che-incubator/kubernetes-image-puller/commit/662f9817d0240043616531d3a2b180a5423c726d), image puller builds contain a golang-based `sleep` binary that can be copied to your scratch image so that it can then be pulled.
-
-See [this example](https://github.com/eclipse-che/che-machine-exec/commit/62632f753636b5b5ec19ef31ab1928679b193097) showing how to use the sleep command in your container:
-
-```
-FROM quay.io/eclipse/kubernetes-image-puller:e28a7fb as k8s-image-puller
-...
-COPY --from=k8s-image-puller /bin/sleep /bin/sleep
-```
-
-Refs: 
-* https://github.com/eclipse-che/che-machine-exec/blob/main/build/dockerfiles/Dockerfile#L16
-* https://github.com/eclipse-che/che-machine-exec/blob/main/build/dockerfiles/Dockerfile#L60
-
-NOTE: the `sleep` binary is statically compiled and is therefore arch-specific. If you need it for more than one architecture, you'll need to build the image puller image for your specific architecture(s) and copy the correct `sleep` binary into your downstream container.
+As a result, every container (including scratch image containers) uses the provided golang-based `sleep` binary.

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	NodeSelector      map[string]string
 	ImagePullSecrets  []string
 	Affinity          *corev1.Affinity
+	ImagePullerImage  string
 }
 
 func GetConfig() Config {
@@ -41,5 +42,6 @@ func GetConfig() Config {
 		NodeSelector:      processNodeSelectorEnvVar(),
 		ImagePullSecrets:  processImagePullSecretsEnvVar(),
 		Affinity:          processAffinityEnvVar(),
+		ImagePullerImage:  getEnvVarOrDefault(kipImageEnvVar, defaultImage),
 	}
 }

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -39,6 +39,7 @@ func TestEnvVars(t *testing.T) {
 				NodeSelector:      map[string]string{},
 				ImagePullSecrets:  []string{},
 				Affinity:          &v1.Affinity{},
+				ImagePullerImage:  "quay.io/eclipse/kubernetes-image-puller:next",
 			},
 		},
 		{
@@ -50,6 +51,7 @@ func TestEnvVars(t *testing.T) {
 				"CACHING_CPU_REQUEST": ".055",
 				"IMAGE_PULL_SECRETS":  "secret1; secret2",
 				"AFFINITY":            `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/e2e-az-name","operator":"In","values":["e2e-az1","e2e-az2"]}]}]}}}`,
+				"KIP_IMAGE":           "quay.io/my-repo/kubernetes-image-puller:next",
 			},
 			want: Config{
 				DaemonsetName: "custom-daemonset-name",
@@ -83,6 +85,7 @@ func TestEnvVars(t *testing.T) {
 						},
 					},
 				},
+				ImagePullerImage: "quay.io/my-repo/kubernetes-image-puller:next",
 			},
 		},
 	}

--- a/cfg/envvars.go
+++ b/cfg/envvars.go
@@ -35,6 +35,7 @@ const (
 	nodeSelectorEnvVar      = "NODE_SELECTOR"
 	imagePullSecretsEnvVar  = "IMAGE_PULL_SECRETS"
 	affinityEnvVar          = "AFFINITY"
+	kipImageEnvVar          = "KIP_IMAGE"
 )
 
 // Default values where applicable
@@ -50,6 +51,7 @@ const (
 	defaultNodeSelector      = "{}"
 	defaultImagePullSecret   = ""
 	defaultAffinity          = "{}"
+	defaultImage             = "quay.io/eclipse/kubernetes-image-puller:next"
 )
 
 func getCachingInterval() int {

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,7 +1,7 @@
 deploymentName: kubernetes-image-puller
 image: 
   repository: quay.io/eclipse/kubernetes-image-puller
-  tag: latest
+  tag: next
 serviceAccount:
   name: k8s-image-puller
 configMap:

--- a/deploy/openshift/app.yaml
+++ b/deploy/openshift/app.yaml
@@ -43,4 +43,4 @@ parameters:
 - name: IMAGE
   value: quay.io/eclipse/kubernetes-image-puller
 - name: IMAGE_TAG
-  value: latest
+  value: next

--- a/utils/clusterutils.go
+++ b/utils/clusterutils.go
@@ -29,6 +29,11 @@ import (
 
 var propagationPolicy = metav1.DeletePropagationForeground
 var terminationGracePeriodSeconds = int64(1)
+
+// Volume mount to copy the sleep binary into.
+// To allow the image puller to cache scratch images, an initContainer copies
+// the sleep binary to this volume mount. As a result, every container has
+// access to the sleep binary via this volume mount.
 var containerVolumeMounts = []corev1.VolumeMount{
 	{Name: "kip", MountPath: "/kip"},
 }
@@ -104,7 +109,7 @@ func getDaemonset(deployment *appsv1.Deployment) *appsv1.DaemonSet {
 					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 					InitContainers: []corev1.Container{{
 						Name:            "copy-sleep",
-						Image:           "quay.io/eclipse/kubernetes-image-puller:next",
+						Image:           cfg.ImagePullerImage,
 						ImagePullPolicy: corev1.PullAlways,
 						Command:         []string{"/bin/sh"},
 						Args:            []string{"-c", "cp bin/sleep kip/sleep"},

--- a/utils/clusterutils_test.go
+++ b/utils/clusterutils_test.go
@@ -25,8 +25,9 @@ var (
 		},
 	}
 
-	defaultCommand = []string{"sleep"}
-	defaultArgs    = []string{"720h"}
+	defaultCommand      = []string{"/kip/sleep"}
+	defaultArgs         = []string{"720h"}
+	defaultVolumeMounts = []corev1.VolumeMount{{Name: "kip", MountPath: "/kip"}}
 )
 
 // This is the only function that does not require a kubernetes client.  The rest of the tests are in ./e2e
@@ -47,6 +48,7 @@ func TestGetContainers(t *testing.T) {
 				Args:            defaultArgs,
 				ImagePullPolicy: corev1.PullAlways,
 				Resources:       defaultResourceRequirements,
+				VolumeMounts:    defaultVolumeMounts,
 			}, {
 				Name:            "che-plugin-registry",
 				Image:           "quay.io/eclipse/che-plugin-registry:nightly",
@@ -54,6 +56,7 @@ func TestGetContainers(t *testing.T) {
 				Args:            defaultArgs,
 				ImagePullPolicy: corev1.PullAlways,
 				Resources:       defaultResourceRequirements,
+				VolumeMounts:    defaultVolumeMounts,
 			}},
 			images: "che-theia=eclipse/che-theia:nightly;che-plugin-registry=quay.io/eclipse/che-plugin-registry:nightly",
 		}, {
@@ -65,6 +68,7 @@ func TestGetContainers(t *testing.T) {
 				Args:            defaultArgs,
 				ImagePullPolicy: corev1.PullAlways,
 				Resources:       defaultResourceRequirements,
+				VolumeMounts:    defaultVolumeMounts,
 			}, {
 				Name:            "che-plugin-registry",
 				Image:           "quay.io/eclipse/che-plugin-registry:nightly",
@@ -72,6 +76,7 @@ func TestGetContainers(t *testing.T) {
 				Args:            defaultArgs,
 				ImagePullPolicy: corev1.PullAlways,
 				Resources:       defaultResourceRequirements,
+				VolumeMounts:    defaultVolumeMounts,
 			}, {
 				Name:            "che-devfile-registry",
 				Image:           "quay.io/eclipse/che-devfile-registry:nightly",
@@ -79,6 +84,7 @@ func TestGetContainers(t *testing.T) {
 				Args:            defaultArgs,
 				ImagePullPolicy: corev1.PullAlways,
 				Resources:       defaultResourceRequirements,
+				VolumeMounts:    defaultVolumeMounts,
 			}, {
 				Name:            "che-theia",
 				Image:           "quay.io/eclipse/che-theia:nightly",
@@ -86,6 +92,7 @@ func TestGetContainers(t *testing.T) {
 				Args:            defaultArgs,
 				ImagePullPolicy: corev1.PullAlways,
 				Resources:       defaultResourceRequirements,
+				VolumeMounts:    defaultVolumeMounts,
 			}},
 			images: "che-sidecar-java=quay.io/eclipse/che-sidecar-java:nightly;che-plugin-registry=quay.io/eclipse/che-plugin-registry:nightly;che-devfile-registry=quay.io/eclipse/che-devfile-registry:nightly;che-theia=quay.io/eclipse/che-theia:nightly",
 		},


### PR DESCRIPTION
Fixes https://github.com/eclipse/che/issues/16689, based on the POC provided: https://github.com/eclipse/che/issues/16689#issuecomment-836834268.

This PR creates an ` initContainer` with the `quay.io/eclipse/kubernetes-image-puller:next` image, and copies over the sleep binary to a volume mount. Every pre-pulled image container uses the sleep binary from the volume mount, allowing the image puller to pre-pull scratch images.

### To test this PR on CRC:
Image: `quay.io/dkwon17/kubernetes-image-puller:che-16689`

1. Edit `deploy/openshift/app.yaml` so that the deployment deploys `quay.io/dkwon17/kubernetes-image-puller:che-16689`.
```
parameters:
...
- name: IMAGE
  value: quay.io/eclipse/kubernetes-image-puller
- name: IMAGE_TAG
  value: next
```
2. Add a scratch image to the config map definition in `deploy/openshift/configmap.yaml`, in the `parameters.value` field:
```
parameters:
- name: IMAGES
  value: >
      java11-maven=quay.io/eclipse/che-java11-maven:nightly;
      che-theia=quay.io/eclipse/che-theia:next;
      java-plugin-runner=eclipse/che-remote-plugin-runner-java8:latest;
      scratch=quay.io/dkwon17/scratch:next;
```
3. Start crc and deploy the image puller
```
oc new-project k8s-image-puller && oc process -f deploy/openshift/serviceaccount.yaml | oc apply -f - && oc process -f deploy/openshift/configmap.yaml | oc apply -f - && oc process -f deploy/openshift/app.yaml | oc apply -f -
```

4. After a few minutes, there will be a `kubernetes-image-puller-*` pod in the `k8s-image-puller` project with the scratch image pre-pulled:
![image](https://user-images.githubusercontent.com/83611742/127041710-8c467564-0ca9-4a48-8497-d7585b5ad88e.png)
