### PR TITLE
chore(tests): Add e2e tests for pre-pulling different types of images

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,17 +131,16 @@ docker build -t ${DOCKERIMAGE_NAME}:${DOCKERIMAGE_TAG} -f ./docker/Dockerfile .
 ```
 
 ## Testing
-
+To run the unit tests:
 ```shell
 make test
 ```
 
-Will run unit tests.
-
-End to end tests require [kind](https://github.com/kubernetes-sigs/kind):
+End to end tests require [kind](https://github.com/kubernetes-sigs/kind).
+Note that kind should not be installed with `go get` from this repository's directory.
 
 ```shell
-GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0
+cd $HOME && GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0 && cd ~-
 
 ./hack/run-e2e.sh
 ```

--- a/e2e/deploy_test.go
+++ b/e2e/deploy_test.go
@@ -11,57 +11,82 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func setup(t *testing.T) *kubernetes.Clientset {
-	kubeConfigVar := os.Getenv("KUBECONFIG")
+var (
+	namespace               = os.Getenv("NAMESPACE")
+	kubeConfig              = os.Getenv("KUBECONFIG")
+	daemonsetName           = os.Getenv("DAEMONSET_NAME")
+	daemonsetTimeoutSeconds = time.Duration(120) * time.Second
+)
+
+func getKubeConfig(t *testing.T) (*rest.Config, error) {
 	var config *rest.Config
 	var err error
-	if kubeConfigVar != "" {
+	if kubeConfig != "" {
 		t.Logf("No kubeconfig")
-		config, err = clientcmd.BuildConfigFromFlags("", kubeConfigVar)
+		config, err = clientcmd.BuildConfigFromFlags("", kubeConfig)
 	} else {
 		t.Logf("Using ~/.kube/config")
 		config, err = clientcmd.BuildConfigFromFlags("", path.Join(os.Getenv("HOME"), ".kube", "config"))
 	}
 	if err != nil {
-		t.Errorf("Error creating rest config: %v", err)
+		t.Errorf("Error creating rest config")
+		return nil, err
 	}
-	c := kubernetes.NewForConfigOrDie(config)
-	_, err = c.CoreV1().Namespaces().Create(&corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "k8s-image-puller",
-		},
-	})
-	if err != nil {
-		t.Errorf("Error creating namespace %v", err)
-	}
-	go singleCluster.CacheImages()
-	return c
+	return config, nil
 }
 
-func teardown(clientset *kubernetes.Clientset, t *testing.T) {
-	utils.DeleteDaemonsetIfExists(clientset)
-	err := clientset.CoreV1().Namespaces().Delete("k8s-image-puller", metav1.NewDeleteOptions(30))
+func getClientset(t *testing.T) (*kubernetes.Clientset, error) {
+	config, err := getKubeConfig(t)
 	if err != nil {
-		t.Errorf("Could not delete namespace: %v", err)
+		return nil, err
 	}
+
+	c := kubernetes.NewForConfigOrDie(config)
+	return c, nil
 }
 
 func TestSingleClusterCacheImages(t *testing.T) {
-	clientset := setup(t)
-	defer teardown(clientset, t)
+
+	type testCase struct {
+		name   string
+		images string
+	}
+
+	testCases := []testCase{
+		{name: "test images", images: "che-theia=quay.io/eclipse/che-theia:next;che-plugin-registry=quay.io/eclipse/che-plugin-registry:next"},
+		{name: "test scratch image", images: "che-machine-exec=quay.io/eclipse/che-machine-exec:next;"},
+		{name: "test volume mount image", images: "volume-mount-image=quay.io/dkwon17/volume-mount:latest"},
+	}
+
+	clientset, err := getClientset(t)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			os.Setenv("IMAGES", test.images)
+			cacheImages(t, clientset)
+		})
+	}
+}
+
+func cacheImages(t *testing.T, clientset *kubernetes.Clientset) {
+	go singleCluster.CacheImages()
 
 	dsListChan := make(chan appsv1.DaemonSetList)
 
 	go func() {
 		for {
-			daemonsets, err := clientset.AppsV1().DaemonSets("k8s-image-puller").List(metav1.ListOptions{})
+			daemonsets, err := clientset.AppsV1().DaemonSets(namespace).List(metav1.ListOptions{})
 			if err != nil {
 				t.Errorf("Error listing daemonsets: %v", err)
 			}
@@ -79,17 +104,49 @@ func TestSingleClusterCacheImages(t *testing.T) {
 	select {
 	case gotDS := <-dsListChan:
 		gotDaemonsets = gotDS
-	case <-time.After(120 * time.Second):
-		t.Errorf("Timeout waiting for daemonsets")
+	case <-time.After(daemonsetTimeoutSeconds):
+		checkPods(t, clientset)
+		t.Errorf("Timeout waiting for a ready daemonset (%v)", daemonsetTimeoutSeconds)
 	}
 
 	if len(gotDaemonsets.Items) != 1 {
-		t.Errorf("Wanted 1 daemonset but got %v", len(gotDaemonsets.Items))
+		t.Errorf("Wanted 1 ready daemonset but got %v", len(gotDaemonsets.Items))
 	}
 
 	if len(gotDaemonsets.Items) == 1 {
-		if gotDaemonsets.Items[0].Name != "kubernetes-image-puller" {
-			t.Errorf("Expected daemonset named kubernetes-image-puller, got %v", gotDaemonsets.Items[0].Name)
+		if gotDaemonsets.Items[0].Name != daemonsetName {
+			t.Errorf("Expected daemonset named %v, got %v", daemonsetName, gotDaemonsets.Items[0].Name)
 		}
 	}
+
+	utils.DeleteDaemonsetIfExists(clientset)
+}
+
+func checkPods(t *testing.T, clientset *kubernetes.Clientset) {
+	pods, err := clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		t.Errorf("Error listing pods: %v", err)
+	}
+	for _, pod := range pods.Items {
+		if pod.ObjectMeta.OwnerReferences[0].Name == daemonsetName {
+			for _, containerStatus := range pod.Status.ContainerStatuses {
+				if containerStatus.State.Waiting != nil {
+					t.Error(getWaitingErrorMessage(containerStatus))
+				}
+			}
+		}
+	}
+}
+
+func getWaitingErrorMessage(containerStatus v1.ContainerStatus) string {
+	container := "Waiting container '" + containerStatus.Name + "'"
+	reason := ""
+	message := ""
+	if len(containerStatus.State.Waiting.Reason) > 0 {
+		reason = ", reason: '" + containerStatus.State.Waiting.Reason + "'"
+	}
+	if len(containerStatus.State.Waiting.Message) > 0 {
+		message = ", message: '" + containerStatus.State.Waiting.Message + "'"
+	}
+	return container + reason + message
 }

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -1,17 +1,39 @@
 #!/bin/bash
 
-function cleanup() {
+export CACHING_INTERVAL_HOURS='1'
+export DEPLOYMENT_NAME='kubernetes-image-puller'
+export NAMESPACE='k8s-image-puller'
+export DAEMONSET_NAME='kubernetes-image-puller'
+
+function createClusterIfNeeded() {
+  if [[ $(kind get clusters | grep k8s-image-puller-e2e | wc -l) == '0' ]]; then 
+    kind create cluster --name k8s-image-puller-e2e 
+  fi
+}
+
+function setContext() {
+  kubectl config set current-context kind-k8s-image-puller-e2e
+}
+
+function setupCluster() {
+  kubectl create namespace k8s-image-puller
+  helm template -s templates/app.yaml ./deploy/helm | kubectl apply -n k8s-image-puller -f -
+}
+
+function cleanupCluster() {
+  kubectl delete namespace k8s-image-puller --wait=true
+}
+
+function deleteCuster() {
   kind delete cluster --name k8s-image-puller-e2e
 }
 
-if [[ $(kind get clusters | grep k8s-image-puller-e2e | wc -l) == '0' ]]; then 
-  kind create cluster --name k8s-image-puller-e2e 
-fi
-kubectl config set current-context kind-k8s-image-puller-e2e
-export CACHING_INTERVAL_HOURS='1'
-export IMAGES='che-theia=quay.io/eclipse/che-theia:next;che-plugin-registry=quay.io/eclipse/che-plugin-registry:next'
-go test -count=1 -v ./e2e... 
+createClusterIfNeeded
+setContext
+setupCluster
+go test -count=1 -v ./e2e...
+cleanupCluster
 
 if [[ $1 == "--rm" ]]; then
-  cleanup
+  deleteCuster
 fi

--- a/utils/clusterutils.go
+++ b/utils/clusterutils.go
@@ -170,8 +170,8 @@ func waitDaemonsetReady(c <-chan watch.Event) error {
 		select {
 		case ev, ok := <-c:
 			if !ok {
-				log.Printf("WARN: Watch closed before deamonset ready")
-				return fmt.Errorf("Watch closed before deamonset ready")
+				log.Printf("WARN: Watch closed before daemonset ready")
+				return fmt.Errorf("Watch closed before daemonset ready")
 			}
 			// log.Printf("(DEBUG) Create watch event received: %s", ev.Type)
 			if ev.Type == watch.Modified {
@@ -241,7 +241,7 @@ func waitDaemonsetDeleted(c <-chan watch.Event) {
 		select {
 		case ev, ok := <-c:
 			if !ok {
-				log.Printf("WARN: Watch closed before deamonset deleted")
+				log.Printf("WARN: Watch closed before daemonset deleted")
 				return
 			}
 			log.Printf("(DEBUG) Delete watch event received: %s", ev.Type)


### PR DESCRIPTION
For https://github.com/eclipse/che/issues/20156
* updated to create a deployment in the bash file, since a [deployment is needed to create the daemonset](https://github.com/dkwon17/kubernetes-image-puller/blob/76818c62a521aa67ec7f793bb62fb1abcf5f0d11/utils/clusterutils.go#L146-L147)
* now creates and deletes the namespace in the bash script
* added tests for prepulling images with different types of images