### PR TITLE
Nightly tag was removed, replace with next

### DIFF
--- a/deploy/openshift/configmap.yaml
+++ b/deploy/openshift/configmap.yaml
@@ -25,7 +25,7 @@ objects:
 parameters:
 - name: IMAGES
   value: >
-      java11-maven=quay.io/eclipse/che-java11-maven:nightly;
+      java11-maven=quay.io/eclipse/che-java11-maven:next;
       che-theia=quay.io/eclipse/che-theia:next;
       java-plugin-runner=eclipse/che-remote-plugin-runner-java8:latest;
 - name: DAEMONSET_NAME


### PR DESCRIPTION
The nightly tag for java11-maven=quay.io/eclipse/che-java11-maven has been removed and replaced with next. Tested and working again on OpenShift 4.