### PR TITLE
feat: support multi helm charts installation

### DIFF
--- a/deploy/helm/templates/configmap.yaml
+++ b/deploy/helm/templates/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.configMap.name }}
 data:
   IMAGES: "{{ .Values.configMap.images }}"
-  DAEMONSET_NAME: "kubernetes-image-puller"
+  DAEMONSET_NAME: "{{ .Values.deploymentName }}"
   CACHING_INTERVAL_HOURS: "{{ .Values.configMap.cachingIntervalHours }}"
   NAMESPACE: "{{ .Release.Namespace }}"
   CACHING_MEMORY_REQUEST: "{{ .Values.configMap.cachingMemoryRequest }}"

--- a/deploy/helm/templates/serviceaccount.yaml
+++ b/deploy/helm/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: create-daemonset
+  name: {{ .Values.serviceAccount.name }}
 rules:
 - apiGroups:
   - apps
@@ -17,11 +17,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: create-daemonset
+  name: {{ .Values.serviceAccount.name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: create-daemonset
+  name: {{ .Values.serviceAccount.name }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name }}


### PR DESCRIPTION
I have a request that different nodes prefetch different images so I need to deploy more than one helm charts in kubernetes. 
The fixed name of daemonset and role will make it hard to install more than one helm charts.