### PR TITLE
Refactor/improve Helm chart

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,4 +1,5 @@
+---
 apiVersion: v1
 name: kubernetes-image-puller
-version: 1.0.0
-description: The kubernetes image puller downloads che images ahead of time for faster workspace startup
+version: 2.0.0
+description: Downloads images ahead of time for faster container startups

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "common.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "common.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "common.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Kubernetes and Helm standard labels.
+*/}}
+{{- define "common.labels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ include "common.name" . }}
+helm.sh/chart: {{ include "common.chart" . }}
+{{- end -}}
+
+{{/*
+Labels to use in matchLabels and selector.
+*/}}
+{{- define "common.selectorLabels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: {{ include "common.name" . }}
+{{- end -}}
+
+{{/*
+Return image for containers.
+*/}}
+{{- define "common.image" -}}
+{{- $separator := ":" -}}
+{{- $termination := .Values.image.tag | default .Chart.AppVersion -}}
+{{- if .Values.image.digest }}
+    {{- $separator = "@" -}}
+    {{- $termination = .Values.image.digest -}}
+{{- end -}}
+{{- if .Values.image.registry }}
+    {{- printf "%s/%s%s%s" .Values.image.registry .Values.image.repository $separator $termination -}}
+{{- else -}}
+    {{- printf "%s%s%s" .Values.image.repository $separator $termination -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/templates/configmap.yaml
+++ b/deploy/helm/templates/configmap.yaml
@@ -1,16 +1,16 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.configMap.name }}
+  name: {{ include "common.fullname" . }}
+  labels: {{- include "common.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
-  IMAGES: "{{ .Values.configMap.images }}"
-  DAEMONSET_NAME: "{{ .Values.deploymentName }}"
-  CACHING_INTERVAL_HOURS: "{{ .Values.configMap.cachingIntervalHours }}"
   NAMESPACE: "{{ .Release.Namespace }}"
-  CACHING_MEMORY_REQUEST: "{{ .Values.configMap.cachingMemoryRequest }}"
-  CACHING_MEMORY_LIMIT: "{{ .Values.configMap.cachingMemoryLimit }}"
-  CACHING_CPU_REQUEST: "{{ .Values.configMap.cachingCpuRequest }}"
-  CACHING_CPU_LIMIT: "{{ .Values.configMap.cachingCpuLimit }}"
-  NODE_SELECTOR: "{{ .Values.configMap.nodeSelector }}"
-  IMAGE_PULL_SECRETS: "{{ .Values.configMap.imagePullSecrets }}"
-  AFFINITY: "{{ .Values.configMap.affinity }}"
+  DEPLOYMENT_NAME: "{{ template "common.fullname" . }}"
+  DAEMONSET_NAME: "{{ template "common.fullname" . }}"
+  {{- range $key,$value := .Values.environment }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "common.fullname" . }}
+  {{- with .Values.deployment.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels: {{- include "common.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.deployment.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{- include "common.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: "Recreate"
+  template:
+    metadata:
+      annotations:
+        "checksum/config": {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
+        {{- with .Values.pod.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels: {{- include "common.labels" . | nindent 8 }}
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.pod.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "common.fullname" . }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: kubernetes-image-puller
+          image: {{ include "common.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "common.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/templates/rbac.yaml
+++ b/deploy/helm/templates/rbac.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "common.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  verbs:
+  - create
+  - delete
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "common.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "common.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "common.fullname" . }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "common.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,20 +1,45 @@
-deploymentName: kubernetes-image-puller
-image: 
-  repository: quay.io/eclipse/kubernetes-image-puller
-  tag: next
-serviceAccount:
-  name: k8s-image-puller
-configMap:
-  name: k8s-image-puller
-  images: >
+---
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+image:
+  registry: quay.io/eclipse
+  repository: kubernetes-image-puller
+  tag: "bdf0ed3"
+  digest: ""
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+commonLabels: {}
+
+environment:
+  AFFINITY: "{}"
+  CACHING_CPU_LIMIT: ".2"
+  CACHING_CPU_REQUEST: ".05"
+  CACHING_INTERVAL_HOURS: 1
+  CACHING_MEMORY_LIMIT: "20Mi"
+  CACHING_MEMORY_REQUEST: "10Mi"
+  IMAGE_PULL_SECRETS: ""
+  IMAGES: >
     java11-maven=quay.io/eclipse/che-java11-maven:nightly;
     che-theia=quay.io/eclipse/che-theia:next;
     java-plugin-runner=eclipse/che-remote-plugin-runner-java8:latest;
-  cachingIntervalHours: 1
-  cachingMemoryRequest: "10Mi"
-  cachingMemoryLimit: "20Mi"
-  cachingCpuRequest: ".05"
-  cachingCpuLimit: ".2"
-  nodeSelector: "{}"
-  imagePullSecrets: ""
-  affinity: "{}"
+  NODE_SELECTOR: "{}"
+
+deployment:
+  annotations: {}
+  labels: {}
+
+pod:
+  annotations: {}
+  labels: {}
+
+affinity: {}
+nodeSelector: {}
+resources:
+  limits:
+    cpu: 10m
+    memory: 20Mi
+tolerations: []

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   registry: quay.io/eclipse
   repository: kubernetes-image-puller
-  tag: "bdf0ed3"
+  tag: "next"
   digest: ""
   pullPolicy: IfNotPresent
   pullSecrets: []


### PR DESCRIPTION
* Trying to improve the helm chart using a helper and standard practices/labels

* Explicitly/generically set environment variables from a configmap, instead of defining Helm key/value pairs that are translated to a environment variable within the configmap, except for `NAMESPACE`, `DEPLOYMENT_NAME`, `DAEMONSET_NAME`  which are dynamic

WIP: tested out in my own Kubernetes cluster, still refining things