### PR TITLE
Feature/tolerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The config values to be set are:
 | `NAMESPACE`              | Namespace where daemonset is to be created | `kubernetes-image-puller` |
 | `IMAGES`                 | List of images to be cached, in this format `<name>=<image>;...` | Contains a default list of images, but should be configured when deploying |
 | `NODE_SELECTOR` | Node selector applied to pods created by the daemonset, provided in this format `'{"key":"value"}'`      | `'{}'` |
+| `TOLERATIONS` | Tolerations to be applied to pods to be scheduled on to tainted nodes. Format: `"key=value:Effect"` | `""` |
 | `IMAGE_PULL_SECRETS` | List of image pull secrets, in this format `pullsecret1;...` to add to pods created by the DaemonSet. Those secrets need to be in the image puller's namespace and a cluster administrator must create them.       | `""` |
 | `AFFINITY` | Affinity applied to pods created by the daemonset, in this format `'{"nodeAffinity":{ ... }}'`       | `'{}'` |
 | `KIP_IMAGE` | The image puller image to copy the `sleep` binary from | `quay.io/eclipse/kubernetes-image-puller:next` |
@@ -46,7 +47,8 @@ The following values can be set:
 | `configMap.cachingMemoryLimit`   | The value of `CACHING_MEMORY_LIMIT` to be set in the ConfigMap | `"20Mi"`                                              |
 | `configMap.cachingCpuRequest`    | The value of `CACHING_CPU_REQUEST` to be set in the ConfigMap | `.05`                                                 |
 | `configMap.cachingCpuLimit`      | The value of `CACHING_CPU_LIMIT` to be set in the ConfigMap  | `.2`                                                  |
-| `configMap.nodeSelector`         | The value of `NODE_SELECTOR` to be set in the ConfigMap      | `"{}"`                                                |
+| `configMap.nodeSelector`         | The value of `NODE_SELECTOR` to be set in the ConfigMap      | `"{}"`                                                 |
+| `configMap.tolerations`         | The value of `TOLERATIONS` to be set in the ConfigMap      | `""`                                                 |
 | `configMap.imagePullSecrets` | The value of `IMAGE_PULL_SECRETS`       | `""` |
 | `configMap.affinity`         | The value of `AFFINITY` to be set in the ConfigMap      | `"{}"`                                                |
 
@@ -68,6 +70,7 @@ The following values can be set:
 | `CACHING_CPU_LIMIT` | The value of `CACHING_CPU_LIMIT` to be set in the ConfigMap | `.2` |
 | `NAMESPACE` | The value of `NAMESPACE` to be set in the ConfigMap | `k8s-image-puller` |
 | `NODE_SELECTOR` | The value of `NODE_SELECTOR` to be set in the ConfigMap | `"{}"` |
+| `TOLERATIONS` | The value of `TOLERATIONS` to be set in the ConfigMap | `""` |
 | `IMAGE_PULL_SECRETS` | The value of `IMAGE_PULL_SECRETS`       | `""` |
 | `AFFINITY` | The value of `AFFINITY` to be set in the ConfigMap | `"{}"` |
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	CachingInterval   int
 	NodeSelector      map[string]string
 	ImagePullSecrets  []string
-	Tolerations       []map[string]string
+	Tolerations       []corev1.Toleration
 	Affinity          *corev1.Affinity
 	ImagePullerImage  string
 }

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	CachingInterval   int
 	NodeSelector      map[string]string
 	ImagePullSecrets  []string
+	Tolerations       []map[string]string
 	Affinity          *corev1.Affinity
 	ImagePullerImage  string
 }
@@ -41,6 +42,7 @@ func GetConfig() Config {
 		CachingCpuLimit:   getEnvVarOrDefault(cachingCpuLimitEnvVar, defaultCachingCpuLimit),
 		NodeSelector:      processNodeSelectorEnvVar(),
 		ImagePullSecrets:  processImagePullSecretsEnvVar(),
+		Tolerations:       processTolerationsEnvVar(),
 		Affinity:          processAffinityEnvVar(),
 		ImagePullerImage:  getEnvVarOrDefault(kipImageEnvVar, defaultImage),
 	}

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -37,6 +37,7 @@ func TestEnvVars(t *testing.T) {
 				CachingCpuLimit:   ".2",
 				CachingInterval:   5,
 				NodeSelector:      map[string]string{},
+				Tolerations:       []v1.Toleration{},
 				ImagePullSecrets:  []string{},
 				Affinity:          &v1.Affinity{},
 				ImagePullerImage:  "quay.io/eclipse/kubernetes-image-puller:next",
@@ -48,6 +49,7 @@ func TestEnvVars(t *testing.T) {
 				"DAEMONSET_NAME":      "custom-daemonset-name",
 				"NAMESPACE":           "my-namespace",
 				"NODE_SELECTOR":       "{\"type\": \"compute\"}",
+				"TOLERATIONS":         "key=value:NoSchedule;key1=value1:NoExecute",
 				"CACHING_CPU_REQUEST": ".055",
 				"IMAGE_PULL_SECRETS":  "secret1; secret2",
 				"AFFINITY":            `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/e2e-az-name","operator":"In","values":["e2e-az1","e2e-az2"]}]}]}}}`,
@@ -66,6 +68,20 @@ func TestEnvVars(t *testing.T) {
 				CachingInterval:   5,
 				NodeSelector: map[string]string{
 					"type": "compute",
+				},
+				Tolerations: []v1.Toleration{
+					v1.Toleration{
+						Key:      "key",
+						Value:    "value",
+						Operator: "Equal",
+						Effect:   v1.TaintEffectNoSchedule,
+					},
+					v1.Toleration{
+						Key:      "key1",
+						Value:    "value1",
+						Operator: "Equal",
+						Effect:   v1.TaintEffectNoExecute,
+					},
 				},
 				ImagePullSecrets: []string{"secret1", "secret2"},
 				Affinity: &v1.Affinity{

--- a/cfg/envvars.go
+++ b/cfg/envvars.go
@@ -121,18 +121,23 @@ func convertToTaintEffect(effectString string) (corev1.TaintEffect, error) {
 }
 
 func processTolerationsEnvVar() []corev1.Toleration {
-	rawTolerations := getEnvVarOrDefault(corev1.TolerationsAnnotationKey, defaultTolerations)
-	tolerationString := strings.Split(rawTolerations, ";")
+	rawTolerations := getEnvVarOrDefault(tolerationsEnvVar, defaultTolerations)
+	rawTolerations = strings.TrimSpace(rawTolerations)
+
+	if rawTolerations == "" {
+		return []corev1.Toleration{}
+	}
+
+	tolerationList := strings.Split(rawTolerations, ";")
 	var tolerations []corev1.Toleration
 
-	for _, toleration := range tolerationString {
-		parts := strings.Split(toleration, ":")
+	for _, toleration := range tolerationList {
+		parts := strings.Split(strings.TrimSpace(toleration), ":")
 		if len(parts) != 2 {
 			log.Fatalf("invalid toleration format")
 		}
 
 		keyValue := parts[0]
-
 		effect, err := convertToTaintEffect(parts[1])
 		if err != nil {
 			log.Fatalf("invalid toleration effect")

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: kubernetes-image-puller
-version: 1.0.0
+version: 1.1.0
 description: The kubernetes image puller downloads che images ahead of time for faster workspace startup

--- a/deploy/helm/templates/configmap.yaml
+++ b/deploy/helm/templates/configmap.yaml
@@ -12,5 +12,6 @@ data:
   CACHING_CPU_REQUEST: "{{ .Values.configMap.cachingCpuRequest }}"
   CACHING_CPU_LIMIT: "{{ .Values.configMap.cachingCpuLimit }}"
   NODE_SELECTOR: "{{ .Values.configMap.nodeSelector }}"
+  TOLERATIONS: "{{ .Values.configMap.tolerations }}"
   IMAGE_PULL_SECRETS: "{{ .Values.configMap.imagePullSecrets }}"
   AFFINITY: "{{ .Values.configMap.affinity }}"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -16,5 +16,6 @@ configMap:
   cachingCpuRequest: ".05"
   cachingCpuLimit: ".2"
   nodeSelector: "{}"
+  tolerations: ""
   imagePullSecrets: ""
   affinity: "{}"

--- a/deploy/openshift/configmap.yaml
+++ b/deploy/openshift/configmap.yaml
@@ -20,6 +20,7 @@ objects:
     CACHING_CPU_REQUEST: ${CACHING_CPU_REQUEST}
     CACHING_CPU_LIMIT: ${CACHING_CPU_LIMIT}
     NODE_SELECTOR: ${NODE_SELECTOR}
+    TOLERATIONS: ${TOLERATIONS}
     IMAGE_PULL_SECRETS: ${IMAGE_PULL_SECRETS}
     AFFINITY: ${AFFINITY}
 parameters:
@@ -44,6 +45,8 @@ parameters:
   value: ".2"
 - name: NODE_SELECTOR
   value: "{}"
+- name: TOLERATIONS
+  value: ""
 - name: IMAGE_PULL_SECRETS
   value: ""
 - name: AFFINITY

--- a/utils/clusterutils.go
+++ b/utils/clusterutils.go
@@ -119,6 +119,7 @@ func getDaemonset(deployment *appsv1.Deployment) *appsv1.DaemonSet {
 				},
 				Spec: corev1.PodSpec{
 					NodeSelector:                  cfg.NodeSelector,
+					Tolerations:                   cfg.Tolerations,
 					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 					InitContainers: []corev1.Container{{
 						Name:            "copy-sleep",


### PR DESCRIPTION
Add support for node tolerations through `TOLERATIONS` env variable, in the format of `key=value:NoSchedule`

```
❯ k get node aks-gpu4cpu-15439062-vmss00001o -o yaml | yq .spec.taints
- effect: NoSchedule
  key: sku
  value: gpu
```

```
❯ k get pods -o wide | grep image
kubernetes-image-puller-4vs98                                  3/3     Running     0               9m25s   10.244.12.8   aks-gpu4cpu-15439062-vmss00001o     <none>           <none>
kubernetes-image-puller-54wtr                                  3/3     Running     0               9m25s   10.244.8.8    aks-gpu4cpu-15439062-vmss00001m     <none>           <none>
kubernetes-image-puller-84t4d                                  3/3     Running     0               9m25s   10.244.7.8    aks-gpu4cpu-15439062-vmss00001l     <none>           <none>
```

```
❯ k get pod kubernetes-image-puller-4vs98 -o yaml | yq .spec.tolerations
- effect: NoSchedule
  key: sku
  operator: Equal
  value: gpu
- effect: NoExecute
  key: node.kubernetes.io/not-ready
  operator: Exists
- effect: NoExecute
  key: node.kubernetes.io/unreachable
  operator: Exists
- effect: NoSchedule
  key: node.kubernetes.io/disk-pressure
  operator: Exists
- effect: NoSchedule
  key: node.kubernetes.io/memory-pressure
  operator: Exists
- effect: NoSchedule
  key: node.kubernetes.io/pid-pressure
  operator: Exists
- effect: NoSchedule
  key: node.kubernetes.io/unschedulable
  operator: Exists
```