### PR TITLE
Optimized error and normal prompts when creating daemonSet exceptions

### DIFF
--- a/utils/clusterutils.go
+++ b/utils/clusterutils.go
@@ -143,7 +143,7 @@ func getDaemonset(deployment *appsv1.Deployment) *appsv1.DaemonSet {
 
 // Create the daemonset, using to-be-cached images as init containers. Blocks
 // until daemonset is ready.
-func createDaemonset(clientset *kubernetes.Clientset) error {
+func createDaemonsetOrDie(clientset *kubernetes.Clientset) {
 	cfg := cfg.GetConfig()
 	thisDeployment := getImagePullerDeployment(clientset)
 	toCreate := getDaemonset(thisDeployment)
@@ -161,8 +161,9 @@ func createDaemonset(clientset *kubernetes.Clientset) error {
 	if watchErr != nil {
 		log.Printf("Unable to watch daemonset for readiness, falling back to manually checking.")
 		checkDaemonsetReadiness(clientset)
+	} else {
+		log.Printf("Daemonset ready.")
 	}
-	return err
 }
 
 // Wait for daemonset to be ready (MODIFIED event with all nodes scheduled)

--- a/utils/operations.go
+++ b/utils/operations.go
@@ -26,10 +26,7 @@ import (
 func CacheImages(clientset *kubernetes.Clientset) {
 	log.Printf("Starting caching process")
 	// Create daemonset, wait for it to be ready
-	if err := createDaemonset(clientset); err != nil {
-		log.Printf("Could not create Daemonset: %v", err)
-	}
-	log.Printf("Daemonset ready.")
+	createDaemonsetOrDie(clientset)
 }
 
 // RefreshCache forces a refresh of all pods in the daemonset, to ensure images
@@ -37,9 +34,7 @@ func CacheImages(clientset *kubernetes.Clientset) {
 func RefreshCache(clientset *kubernetes.Clientset) {
 	log.Printf("Refreshing cached images")
 	DeleteDaemonsetIfExists(clientset)
-	if err := createDaemonset(clientset); err != nil {
-		log.Printf("Could not create Daemonset: %v", err)
-	}
+	CacheImages(clientset)
 	log.Printf("Refreshed images")
 }
 

--- a/vendor/google.golang.org/protobuf/internal/impl/merge_gen.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/merge_gen.go
@@ -6,8 +6,6 @@
 
 package impl
 
-import ()
-
 func mergeBool(dst, src pointer, _ *coderFieldInfo, _ mergeOptions) {
 	*dst.Bool() = *src.Bool()
 }


### PR DESCRIPTION
When ```createDaemonset``` is called, if daemonset fails to be created, the system exits directly. The error is only returned when the watch error occurs, so there is no need to print the error log outside. and as daemonSet has been created at this time, printing "Could not create Daemonset" is misleading. 