### PR TITLE
feat: Update chart to allow updateStrategy to be parameterized

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The following values can be set:
 | `image.repository`               | The repository to pull the image from                        | `quay.io/eclipse/kubernetes-image-puller`             |
 | `image.tag`                      | The image tag to pull                                        | `next`                                                |
 | `serviceAccount.name`            | The name of the ServiceAccount to create                     | `k8s-image-puller`                                    |
+| `updateStrategy.type`            | The updateStrategy type to use when restarting the Deployment| `Recreate`                                            |
 | `configMap.name`                 | The name of the ConfigMap to create                          | `k8s-image-puller`                                    |
 | `configMap.images`               | The value of `IMAGES` to be set in the ConfigMap             | // TODO create a reasonable set of default containers |
 | `configMap.cachingIntervalHours` | The value of `CACHING_INTERVAL_HOURS` to be set in the ConfigMap | `"1"`                                                 |

--- a/deploy/helm/templates/app.yaml
+++ b/deploy/helm/templates/app.yaml
@@ -11,7 +11,7 @@ spec:
     matchLabels:
       app:  {{ .Values.deploymentName }}
   strategy:
-    type: "Recreate"
+    type: {{ .Values.updateStrategy.type }}
   template:
     metadata:
       labels:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,9 +1,11 @@
 deploymentName: kubernetes-image-puller
-image: 
+image:
   repository: quay.io/eclipse/kubernetes-image-puller
   tag: next
 serviceAccount:
   name: k8s-image-puller
+updateStrategy:
+  type: Recreate
 configMap:
   name: k8s-image-puller
   images: >


### PR DESCRIPTION
Hello everyone

I'm opening a PR to update the chart and allow the updateStrategy of the Deployment to be configured.

This feature adds the following

Possibility to set a updateStrategy type to the Deployment. I left Recreate by default which what was in the chart

Let me know what you think.