### PR TITLE
Add some Kyverno best practices

### DIFF
--- a/utils/clusterutils.go
+++ b/utils/clusterutils.go
@@ -40,6 +40,9 @@ var (
 	propagationPolicy             = metav1.DeletePropagationForeground
 	terminationGracePeriodSeconds = int64(1)
 
+	bTrue  = true
+	bFalse = false
+
 	// Volume mount to copy the sleep binary into.
 	// To allow the image puller to cache scratch images, an initContainer copies
 	// the sleep binary to this volume mount. As a result, every container has
@@ -100,7 +103,7 @@ func getDaemonset(deployment *appsv1.Deployment) *appsv1.DaemonSet {
 
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: cfg.DaemonsetName,
+			Name:        cfg.DaemonsetName,
 			Annotations: cfg.DaemonsetAnnotations,
 			OwnerReferences: []metav1.OwnerReference{
 				getOwnerReferenceFromDeployment(deployment),
@@ -130,6 +133,13 @@ func getDaemonset(deployment *appsv1.Deployment) *appsv1.DaemonSet {
 						Args:            []string{"-c", copySleepCommand},
 						VolumeMounts:    containerVolumeMounts,
 						Resources:       getContainerResources(cfg),
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							ReadOnlyRootFilesystem:   &bTrue,
+							AllowPrivilegeEscalation: &bFalse,
+						},
 					}},
 					Containers:       getContainers(),
 					ImagePullSecrets: imgPullSecrets,
@@ -271,6 +281,13 @@ func getContainers() []corev1.Container {
 			Resources:       getContainerResources(cfg),
 			ImagePullPolicy: corev1.PullAlways,
 			VolumeMounts:    containerVolumeMounts,
+			SecurityContext: &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				ReadOnlyRootFilesystem:   &bTrue,
+				AllowPrivilegeEscalation: &bFalse,
+			},
 		}
 		idx++
 	}

--- a/utils/clusterutils.go
+++ b/utils/clusterutils.go
@@ -112,13 +112,15 @@ func getDaemonset(deployment *appsv1.Deployment) *appsv1.DaemonSet {
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"test": "daemonset-test",
+					"test":                   "daemonset-test",
+					"app.kubernetes.io/name": "image-puller",
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"test": "daemonset-test",
+						"test":                   "daemonset-test",
+						"app.kubernetes.io/name": "image-puller",
 					},
 					Name: "test-po",
 				},

--- a/utils/clusterutils_test.go
+++ b/utils/clusterutils_test.go
@@ -25,9 +25,16 @@ var (
 		},
 	}
 
-	defaultCommand      = []string{"/kip/sleep"}
-	defaultArgs         = []string{"720h"}
-	defaultVolumeMounts = []corev1.VolumeMount{{Name: "kip", MountPath: "/kip"}}
+	defaultCommand         = []string{"/kip/sleep"}
+	defaultArgs            = []string{"720h"}
+	defaultVolumeMounts    = []corev1.VolumeMount{{Name: "kip", MountPath: "/kip"}}
+	defaultSecurityContext = corev1.SecurityContext{
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		ReadOnlyRootFilesystem:   &bTrue,
+		AllowPrivilegeEscalation: &bFalse,
+	}
 )
 
 // This is the only function that does not require a kubernetes client.  The rest of the tests are in ./e2e
@@ -49,6 +56,7 @@ func TestGetContainers(t *testing.T) {
 				ImagePullPolicy: corev1.PullAlways,
 				Resources:       defaultResourceRequirements,
 				VolumeMounts:    defaultVolumeMounts,
+				SecurityContext: &defaultSecurityContext,
 			}, {
 				Name:            "che-plugin-registry",
 				Image:           "quay.io/eclipse/che-plugin-registry:nightly",
@@ -57,6 +65,7 @@ func TestGetContainers(t *testing.T) {
 				ImagePullPolicy: corev1.PullAlways,
 				Resources:       defaultResourceRequirements,
 				VolumeMounts:    defaultVolumeMounts,
+				SecurityContext: &defaultSecurityContext,
 			}},
 			images: "che-theia=eclipse/che-theia:nightly;che-plugin-registry=quay.io/eclipse/che-plugin-registry:nightly",
 		}, {
@@ -69,6 +78,7 @@ func TestGetContainers(t *testing.T) {
 				ImagePullPolicy: corev1.PullAlways,
 				Resources:       defaultResourceRequirements,
 				VolumeMounts:    defaultVolumeMounts,
+				SecurityContext: &defaultSecurityContext,
 			}, {
 				Name:            "che-plugin-registry",
 				Image:           "quay.io/eclipse/che-plugin-registry:nightly",
@@ -77,6 +87,7 @@ func TestGetContainers(t *testing.T) {
 				ImagePullPolicy: corev1.PullAlways,
 				Resources:       defaultResourceRequirements,
 				VolumeMounts:    defaultVolumeMounts,
+				SecurityContext: &defaultSecurityContext,
 			}, {
 				Name:            "che-devfile-registry",
 				Image:           "quay.io/eclipse/che-devfile-registry:nightly",
@@ -85,6 +96,7 @@ func TestGetContainers(t *testing.T) {
 				ImagePullPolicy: corev1.PullAlways,
 				Resources:       defaultResourceRequirements,
 				VolumeMounts:    defaultVolumeMounts,
+				SecurityContext: &defaultSecurityContext,
 			}, {
 				Name:            "che-theia",
 				Image:           "quay.io/eclipse/che-theia:nightly",
@@ -93,6 +105,7 @@ func TestGetContainers(t *testing.T) {
 				ImagePullPolicy: corev1.PullAlways,
 				Resources:       defaultResourceRequirements,
 				VolumeMounts:    defaultVolumeMounts,
+				SecurityContext: &defaultSecurityContext,
 			}},
 			images: "che-sidecar-java=quay.io/eclipse/che-sidecar-java:nightly;che-plugin-registry=quay.io/eclipse/che-plugin-registry:nightly;che-devfile-registry=quay.io/eclipse/che-devfile-registry:nightly;che-theia=quay.io/eclipse/che-theia:nightly",
 		},


### PR DESCRIPTION
I recently activated a few default Kyverno rules in my cluster. I noticed that the DaemonSet does not meet a few conditions, even though this would actually be quite easy to do.

Of course, I could edit the resources via Kyverno, but then all other users would have to do the same. . It's easier for everyone to customize the DaemonSet within the application.