### PR TITLE
fix: prevent nil clientset panic and goroutine leak on shutdown

### DIFF
--- a/pkg/single-cluster/puller.go
+++ b/pkg/single-cluster/puller.go
@@ -59,7 +59,7 @@ func cacheImagesLocally(config *rest.Config,
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.Printf("Error creating Clientset: %v", err)
+		log.Fatalf("Error creating Clientset: %v", err)
 	}
 
 	// Clean up existing deployment if necessary
@@ -74,6 +74,7 @@ func cacheImagesLocally(config *rest.Config,
 			log.Printf("Received SIGTERM, deleting daemonset")
 			utils.DeleteDaemonsetIfExists(clientset)
 			wg.Done()
+			return
 		case <-time.After(time.Duration(cfg.CachingInterval) * time.Hour):
 			utils.RefreshCache(clientset)
 			utils.LogNumNodesScheduled(clientset, "(single user mode)")


### PR DESCRIPTION
## Summary

- Fix nil pointer panic: `kubernetes.NewForConfig` error was logged but execution continued with a nil clientset, causing a crash on the first API call. Changed to `log.Fatalf` to fail fast.
- Fix goroutine leak: the SIGTERM handler called `wg.Done()` but did not `return`, so the goroutine continued blocking on the next `select` iteration instead of exiting.

Closes #218

## Test plan

- [x] Unit tests pass
- [ ] Deploy and verify clean shutdown on SIGTERM (daemonset deleted, process exits)
- [ ] Verify startup failure with invalid kubeconfig logs a clear error

Signed-off-by: Chris Brown <snecklifter@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by stopping immediately if client initialization fails.
  * Fixed shutdown behavior so background image caching stops cleanly when the service receives a termination signal.
  * Reduced the chance of lingering work during shutdown by exiting the caching loop after cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->