### PR TITLE
chore: fix all golangci-lint warnings

### DIFF
--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -1,7 +1,6 @@
 package cfg
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,10 +9,8 @@ import (
 
 func TestEnvVars(t *testing.T) {
 
-	defer unsetEnv()
-
-	os.Setenv("IMAGES", "che-theia=quay.io/eclipse/che-theia:nightly")
-	os.Setenv("CACHING_INTERVAL_HOURS", "5")
+	t.Setenv("IMAGES", "che-theia=quay.io/eclipse/che-theia:nightly")
+	t.Setenv("CACHING_INTERVAL_HOURS", "5")
 
 	type testcase struct {
 		name string
@@ -108,7 +105,7 @@ func TestEnvVars(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			for k, v := range c.env {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 			cfg := GetConfig()
 			if d := cmp.Diff(c.want, cfg); d != "" {
@@ -116,9 +113,4 @@ func TestEnvVars(t *testing.T) {
 			}
 		})
 	}
-}
-
-func unsetEnv() {
-	os.Unsetenv("IMAGES")
-	os.Unsetenv("CACHING_INTERVAL_HOURS")
 }

--- a/cfg/envvars_test.go
+++ b/cfg/envvars_test.go
@@ -1,7 +1,6 @@
 package cfg
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -35,8 +34,7 @@ func TestProcessImagesEnvVar(t *testing.T) {
 
 	for _, c := range testcases {
 		t.Run(c.name, func(t *testing.T) {
-			defer os.Clearenv()
-			os.Setenv("IMAGES", c.images)
+			t.Setenv("IMAGES", c.images)
 			got := processImagesEnvVar()
 
 			if d := cmp.Diff(c.want, got); d != "" {
@@ -79,9 +77,8 @@ func TestProcessDaemonsetAnnotationsEnvVar(t *testing.T) {
 
 	for _, c := range testcases {
 		t.Run(c.name, func(t *testing.T) {
-			defer os.Clearenv()
 			if c.isDaemonsetAnnotationsSet {
-				os.Setenv("DAEMONSET_ANNOTATIONS", c.daemonsetAnnotations)
+				t.Setenv("DAEMONSET_ANNOTATIONS", c.daemonsetAnnotations)
 			}
 			got := processDaemonsetAnnotationsEnvVar()
 
@@ -125,9 +122,8 @@ func TestProcessNodeSElectorEnvVar(t *testing.T) {
 
 	for _, c := range testcases {
 		t.Run(c.name, func(t *testing.T) {
-			defer os.Clearenv()
 			if c.isNodeSelectorSet {
-				os.Setenv("NODE_SELECTOR", c.nodeSelector)
+				t.Setenv("NODE_SELECTOR", c.nodeSelector)
 			}
 			got := processNodeSelectorEnvVar()
 
@@ -139,15 +135,13 @@ func TestProcessNodeSElectorEnvVar(t *testing.T) {
 }
 
 func TestGetEnvVarOrDefaultBool(t *testing.T) {
-	defer os.Clearenv()
-	os.Setenv("DEFINED_ENV_VAR", "true")
+	t.Setenv("DEFINED_ENV_VAR", "true")
 	assert.True(t, getEnvVarOrDefaultBool("DEFINED_ENV_VAR", false), "When a variable is defined it should return its value")
 	assert.True(t, getEnvVarOrDefaultBool("UNDEFINED_ENV_VAR", true), "When a variable is not defined it should return the default value")
 }
 
 func TestGetEnvVarOrDefault(t *testing.T) {
-	defer os.Clearenv()
-	os.Setenv("DEFINED_ENV_VAR", "foo")
+	t.Setenv("DEFINED_ENV_VAR", "foo")
 	assert.Equal(t, getEnvVarOrDefault("DEFINED_ENV_VAR", "bar"), "foo", "When a variable is defined it should return it's set value")
 	assert.Equal(t, getEnvVarOrDefault("UNDEFINED_ENV_VAR", "bar"), "bar", "When a variable is undefined it should return the default value")
 }
@@ -198,9 +192,8 @@ func Test_processAffinityEnvVar(t *testing.T) {
 	}
 	for _, c := range tests {
 		t.Run(c.name, func(t *testing.T) {
-			defer os.Clearenv()
 			if c.isAffinitySet {
-				os.Setenv("AFFINITY", c.affinity)
+				t.Setenv("AFFINITY", c.affinity)
 			}
 			got := processAffinityEnvVar()
 
@@ -259,9 +252,8 @@ func TestProcessTolerationsEnvVar(t *testing.T) {
 
 	for _, c := range tests {
 		t.Run(c.name, func(t *testing.T) {
-			defer os.Clearenv()
 			if c.isTolerationsSet {
-				os.Setenv("TOLERATIONS", c.tolerations)
+				t.Setenv("TOLERATIONS", c.tolerations)
 			}
 			got := processTolerationsEnvVar()
 

--- a/e2e/deploy_test.go
+++ b/e2e/deploy_test.go
@@ -23,7 +23,7 @@ var (
 	namespace               = os.Getenv("NAMESPACE")
 	kubeConfig              = os.Getenv("KUBECONFIG")
 	daemonsetName           = os.Getenv("DAEMONSET_NAME")
-	daemonsetTimeoutSeconds = time.Duration(120) * time.Second
+	daemonsetTimeout = 120 * time.Second
 )
 
 func getKubeConfig(t *testing.T) (*rest.Config, error) {
@@ -74,7 +74,7 @@ func TestSingleClusterCacheImages(t *testing.T) {
 	for _, test := range testCases {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			os.Setenv("IMAGES", test.images)
+			t.Setenv("IMAGES", test.images)
 			cacheImages(t, clientset)
 		})
 	}
@@ -105,9 +105,9 @@ func cacheImages(t *testing.T, clientset *kubernetes.Clientset) {
 	select {
 	case gotDS := <-dsListChan:
 		gotDaemonsets = gotDS
-	case <-time.After(daemonsetTimeoutSeconds):
+	case <-time.After(daemonsetTimeout):
 		checkPods(t, clientset)
-		t.Errorf("Timeout waiting for a ready daemonset (%v)", daemonsetTimeoutSeconds)
+		t.Errorf("Timeout waiting for a ready daemonset (%v)", daemonsetTimeout)
 	}
 
 	if len(gotDaemonsets.Items) != 1 {

--- a/sleep/sleep.go
+++ b/sleep/sleep.go
@@ -20,8 +20,8 @@ import (
 )
 
 func displayUsage(out io.Writer) int {
-	fmt.Fprintf(out, "Usage: %s <duration>\n", os.Args[0])
-	fmt.Fprintln(out, "See https://pkg.go.dev/time#ParseDuration")
+	_, _ = fmt.Fprintf(out, "Usage: %s <duration>\n", os.Args[0])
+	_, _ = fmt.Fprintln(out, "See https://pkg.go.dev/time#ParseDuration")
 	return -1
 }
 
@@ -38,7 +38,7 @@ func entryPoint(out io.Writer) int {
 	}
 	duration, err := time.ParseDuration(os.Args[1])
 	if err != nil {
-		fmt.Fprintf(out, "Invalid duration: %s\n", err)
+		_, _ = fmt.Fprintf(out, "Invalid duration: %s\n", err)
 		return displayUsage(out)
 	}
 	time.Sleep(duration)

--- a/utils/clusterutils.go
+++ b/utils/clusterutils.go
@@ -181,27 +181,23 @@ func createDaemonset(clientset *kubernetes.Clientset) error {
 // Wait for daemonset to be ready (MODIFIED event with all nodes scheduled)
 func waitDaemonsetReady(c <-chan watch.Event) error {
 	log.Printf("Waiting for daemonset to be ready")
-	for {
-		select {
-		case ev, ok := <-c:
-			if !ok {
-				log.Printf("WARN: Watch closed before daemonset ready")
-				return fmt.Errorf("Watch closed before daemonset ready")
+	for ev := range c {
+		switch ev.Type {
+		case watch.Modified:
+			daemonset := ev.Object.(*appsv1.DaemonSet)
+			if daemonset.Status.NumberReady == daemonset.Status.DesiredNumberScheduled {
+				log.Printf("%d/%d nodes ready in daemonset", daemonset.Status.NumberReady, daemonset.Status.DesiredNumberScheduled)
+				return nil
 			}
-			// log.Printf("(DEBUG) Create watch event received: %s", ev.Type)
-			if ev.Type == watch.Modified {
-				daemonset := ev.Object.(*appsv1.DaemonSet)
-				// TODO: Not sure if this is the correct logic
-				if daemonset.Status.NumberReady == daemonset.Status.DesiredNumberScheduled {
-					log.Printf("%d/%d nodes ready in daemonset", daemonset.Status.NumberReady, daemonset.Status.DesiredNumberScheduled)
-					return nil
-				}
-				log.Printf("%d/%d nodes ready", daemonset.Status.NumberReady, daemonset.Status.DesiredNumberScheduled)
-			} else if ev.Type == watch.Deleted || ev.Type == watch.Error {
-				log.Fatalf("Error occurred while waiting for daemonset to be ready -- event %s detected", watch.Deleted)
-			}
+			log.Printf("%d/%d nodes ready", daemonset.Status.NumberReady, daemonset.Status.DesiredNumberScheduled)
+		case watch.Deleted, watch.Error:
+			log.Fatalf("Error occurred while waiting for daemonset to be ready -- event %s detected", ev.Type)
+		default:
+			log.Printf("Unexpected watch event type while waiting for daemonset ready: %s", ev.Type)
 		}
 	}
+	log.Printf("WARN: Watch closed before daemonset ready")
+	return fmt.Errorf("watch closed before daemonset ready")
 }
 
 func checkDaemonsetReadiness(clientset *kubernetes.Clientset) {
@@ -252,19 +248,18 @@ func deleteDaemonset(clientset *kubernetes.Clientset) {
 
 // Use watch channel to wait for DELETED event on daemonset, then return
 func waitDaemonsetDeleted(c <-chan watch.Event) {
-	for {
-		select {
-		case ev, ok := <-c:
-			if !ok {
-				log.Printf("WARN: Watch closed before daemonset deleted")
-				return
-			}
-			log.Printf("(DEBUG) Delete watch event received: %s", ev.Type)
-			if ev.Type == watch.Deleted {
-				return
-			}
+	for ev := range c {
+		switch ev.Type {
+		case watch.Deleted:
+			log.Printf("Daemonset deleted")
+			return
+		case watch.Error:
+			log.Printf("Error event received while waiting for daemonset deletion: %s", ev.Type)
+		default:
+			log.Printf("Unexpected watch event type while waiting for daemonset deletion: %s", ev.Type)
 		}
 	}
+	log.Printf("WARN: Watch closed before daemonset deleted")
 }
 
 // Get array of all images in containers to be cached.

--- a/utils/clusterutils_test.go
+++ b/utils/clusterutils_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -112,9 +111,8 @@ func TestGetContainers(t *testing.T) {
 	}
 	for _, c := range testcases {
 		t.Run(c.name, func(t *testing.T) {
-			defer os.Clearenv()
-			os.Setenv("IMAGES", c.images)
-			os.Setenv("CACHING_INTERVAL_HOURS", "1")
+			t.Setenv("IMAGES", c.images)
+			t.Setenv("CACHING_INTERVAL_HOURS", "1")
 			got := getContainers()
 			assert.ElementsMatch(t, c.want, got, "Should contain the same elements, order is not guaranteed")
 		})


### PR DESCRIPTION
## Summary

- Replace `os.Setenv`/`os.Clearenv` in tests with `t.Setenv` — automatically restores environment after each test, avoids destructive `os.Clearenv` that wipes the entire process environment
- Use `for range` over watch channels instead of `for { select {} }` (staticcheck S1000)
- Use tagged switch on watch event types (staticcheck QF1003)
- Lowercase error string per Go conventions (staticcheck ST1005)
- Explicitly discard `fmt.Fprintf`/`fmt.Fprintln` return values in sleep usage output (errcheck)
- Rename `daemonsetTimeoutSeconds` to `daemonsetTimeout` to avoid unit-specific suffix on `time.Duration` (staticcheck ST1011)

`golangci-lint` now reports **0 issues** across all packages.

## Test plan

- [x] `go test ./cfg... ./pkg... ./sleep... ./utils...` passes
- [x] `golangci-lint run` reports 0 issues
- [x] `go vet ./...` clean

Signed-off-by: Chris Brown <snecklifter@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background workload monitoring so readiness and deletion checks handle channel updates more reliably and report clearer timeout behavior.

* **Tests**
  * Updated test setup to use scoped environment variable handling, reducing cross-test interference and improving isolation.

* **Refactor**
  * Simplified several internal loops and cleaned up minor formatting-related code paths without changing user-facing output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->