### PR TITLE
fix: update Dockerfile base images from UBI8 to UBI9

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -8,8 +8,8 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 #
-# https://registry.access.redhat.com/ubi8/go-toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.7 as builder
+# https://registry.access.redhat.com/ubi9/go-toolset
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 as builder
 ENV GOPATH=/go/ \
     GO111MODULE=on
 
@@ -37,8 +37,8 @@ COPY . .
 RUN adduser appuser && \
     make build 
 
-# https://registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.10-1769387960
+# https://registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8
 USER root
 RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 # CRW-528 copy actual cert


### PR DESCRIPTION
## Summary
- Updates builder image from `ubi8/go-toolset:1.25.7` to `ubi9/go-toolset:1.26`
- Updates runtime image from `ubi8-minimal:8.10` to `ubi9/ubi-minimal:9.8`

## Motivation
PR #226 bumped `go.mod` to `go 1.26.0` for the k8s client library upgrade, but the UBI8 go-toolset image only ships Go 1.25.x with `GOTOOLCHAIN=local`, causing `go mod download` to fail with:

```
go: go.mod requires go >= 1.26.0 (running go 1.25.7; GOTOOLCHAIN=local)
```

The Go 1.26 toolset is available on UBI9 but not UBI8. Verified that microdnf, cert paths, and `adduser` all work identically on UBI9.

## Test plan
- [x] `make build` — builds successfully
- [x] `make docker` — container builds and tags successfully with new base images
- [x] Verified cert paths (`/etc/pki/ca-trust/...`) exist on UBI9-minimal
- [x] Verified `microdnf` is available on UBI9-minimal
- [x] Verified `adduser` syntax is compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)