### PR TITLE
fix: handle structured YAML values in Helm configmap template

### DIFF
--- a/deploy/helm/templates/configmap.yaml
+++ b/deploy/helm/templates/configmap.yaml
@@ -5,15 +5,15 @@ metadata:
 data:
   IMAGES: "{{ .Values.configMap.images }}"
   DAEMONSET_NAME: "{{ .Values.deploymentName }}"
-  DAEMONSET_ANNOTATIONS: "{{ .Values.configMap.daemonsetAnnotations }}"
+  DAEMONSET_ANNOTATIONS: {{ if kindIs "string" .Values.configMap.daemonsetAnnotations }}{{ .Values.configMap.daemonsetAnnotations | quote }}{{ else }}{{ .Values.configMap.daemonsetAnnotations | toJson | quote }}{{ end }}
   CACHING_INTERVAL_HOURS: "{{ .Values.configMap.cachingIntervalHours }}"
   NAMESPACE: "{{ .Release.Namespace }}"
   CACHING_MEMORY_REQUEST: "{{ .Values.configMap.cachingMemoryRequest }}"
   CACHING_MEMORY_LIMIT: "{{ .Values.configMap.cachingMemoryLimit }}"
   CACHING_CPU_REQUEST: "{{ .Values.configMap.cachingCpuRequest }}"
   CACHING_CPU_LIMIT: "{{ .Values.configMap.cachingCpuLimit }}"
-  NODE_SELECTOR: "{{ .Values.configMap.nodeSelector }}"
+  NODE_SELECTOR: {{ if kindIs "string" .Values.configMap.nodeSelector }}{{ .Values.configMap.nodeSelector | quote }}{{ else }}{{ .Values.configMap.nodeSelector | toJson | quote }}{{ end }}
   IMAGE_PULL_SECRETS: "{{ .Values.configMap.imagePullSecrets }}"
-  AFFINITY: "{{ .Values.configMap.affinity }}"
-  TOLERATIONS: "{{ .Values.configMap.tolerations }}"
+  AFFINITY: {{ if kindIs "string" .Values.configMap.affinity }}{{ .Values.configMap.affinity | quote }}{{ else }}{{ .Values.configMap.affinity | toJson | quote }}{{ end }}
+  TOLERATIONS: {{ if kindIs "string" .Values.configMap.tolerations }}{{ .Values.configMap.tolerations | quote }}{{ else }}{{ .Values.configMap.tolerations | toJson | quote }}{{ end }}
   KIP_IMAGE: "{{ .Values.configMap.kipImage }}"


### PR DESCRIPTION
## Summary

- When users pass `configMap.nodeSelector`, `configMap.affinity`, `configMap.tolerations`, or `configMap.daemonsetAnnotations` as structured YAML in their values file, the template rendered Go's `fmt.Sprint` output (e.g. `map[key:value]`) instead of valid JSON, causing the image puller to fail on startup
- Use `kindIs`/`toJson` to auto-serialize structured values to JSON while preserving backward compatibility with existing JSON string inputs
- Both input styles now work:
  - **String** (existing): `nodeSelector: '{"key":"value"}'` — passes through unchanged
  - **Structured YAML** (now supported): `nodeSelector: {key: value}` — auto-serialized to JSON

Closes #146
Closes #205

## Test plan

- [x] `helm template deploy/helm` with default `values.yaml` — string defaults rendered correctly
- [x] `helm template deploy/helm -f override.yaml` with structured YAML values — valid JSON produced
- [x] `helm template deploy/helm --set-json 'configMap.nodeSelector={"key":"val"}'` — valid JSON produced
- [x] Verified all four affected fields: `nodeSelector`, `affinity`, `tolerations`, `daemonsetAnnotations`

Signed-off-by: Chris Brown <snecklifter@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)