### PR TITLE
fix: increase e2e test timeout from 120s to 600s

### DIFF
--- a/e2e/deploy_test.go
+++ b/e2e/deploy_test.go
@@ -23,7 +23,7 @@ var (
 	namespace               = os.Getenv("NAMESPACE")
 	kubeConfig              = os.Getenv("KUBECONFIG")
 	daemonsetName           = os.Getenv("DAEMONSET_NAME")
-	daemonsetTimeout = 120 * time.Second
+	daemonsetTimeout = 600 * time.Second
 )
 
 func getKubeConfig(t *testing.T) (*rest.Config, error) {


### PR DESCRIPTION
## Summary

- Increases `daemonsetTimeoutSeconds` from 120s to 600s in e2e tests
- The 120s timeout is insufficient for pulling large container images like `che-plugin-registry` (~2.8GB), causing false DELETED event errors when the daemonset is cleaned up mid-pull

Fixes #235

## Test plan

- [ ] Run e2e tests with cold image cache to verify large images complete within the new timeout
- [ ] Verify existing test cases still pass with warm cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the wait time for a DaemonSet to become ready in end-to-end testing, helping avoid premature timeouts on slower environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->