### PR TITLE
fix: update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -26,12 +26,12 @@ jobs:
     steps:
     -
       name: Clone source code
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         persist-credentials: false
     -
       name: Set up Go
-      uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version-file: go.mod
     -
@@ -50,20 +50,20 @@ jobs:
     steps:
     -
       name: "Set up QEMU"
-      uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
     -
       name: "Set up Docker Buildx"
-      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
     -
       name: "Docker quay.io Login"
-      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
     -
       name: Clone source code
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -77,7 +77,7 @@ jobs:
         echo "image=kubernetes-image-puller" >> $GITHUB_OUTPUT
     -
       name: "Build and push"
-      uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
       with:
         context: .
         file: ./build/dockerfiles/Dockerfile


### PR DESCRIPTION
## Summary

- Updates all GitHub Actions to their latest major versions targeting Node 24
- Resolves `[DEP0040] DeprecationWarning: The punycode module is deprecated` warnings in CI
- Resolves `Node 20 is being deprecated` notices from the GitHub Actions runner

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v3 | v7 |
| `actions/setup-go` | v5 | v6 |
| `docker/setup-qemu-action` | v2 | v4 |
| `docker/setup-buildx-action` | v2 | v4 |
| `docker/login-action` | v2 | v4 |
| `docker/build-push-action` | v3 | v7 |

All SHAs are pinned to digest per project convention.

## Test plan

- [ ] CI runs without Node 20 deprecation or punycode warnings
- [ ] Build job still pushes images correctly (verified on merge to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)