### PR TITLE
fix: derive KIP_IMAGE from image.repository and image.tag in Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ The following values can be set:
 | `configMap.imagePullSecrets`     | The value of `IMAGE_PULL_SECRETS`                                                                                                     | `""`                                                                       |
 | `configMap.affinity`             | The value of `AFFINITY` to be set in the ConfigMap                                                                                    | `"{}"`                                                                     |
 | `configMap.tolerations`          | The value of `TOLERATIONS` to be set in the ConfigMap (escaped JSON) `'[{\"key\":\"foo\",\"operator\":\"Equal\",\"value\":\"bar\"}]'` | `"[]"`                                                                     |
-| `configMap.kipImage`             | The value of `KIP_IMAGE` to be set in the ConfigMap                                                                                   | `quay.io/eclipse/kubernetes-image-puller:next`                             |
 
 ### Configuration - OpenShift
 

--- a/deploy/helm/templates/configmap.yaml
+++ b/deploy/helm/templates/configmap.yaml
@@ -16,4 +16,4 @@ data:
   IMAGE_PULL_SECRETS: "{{ .Values.configMap.imagePullSecrets }}"
   AFFINITY: {{ if kindIs "string" .Values.configMap.affinity }}{{ .Values.configMap.affinity | quote }}{{ else }}{{ .Values.configMap.affinity | toJson | quote }}{{ end }}
   TOLERATIONS: {{ if kindIs "string" .Values.configMap.tolerations }}{{ .Values.configMap.tolerations | quote }}{{ else }}{{ .Values.configMap.tolerations | toJson | quote }}{{ end }}
-  KIP_IMAGE: "{{ .Values.configMap.kipImage }}"
+  KIP_IMAGE: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -25,7 +25,6 @@ configMap:
   affinity: "{}"
   # Tolerations applied to pods created by the daemonset, provided in this format (escaped JSON) `'[{\"key\":\"foo\",\"operator\":\"Equal\",\"value\":\"bar\"}
   tolerations: '[]'
-  kipImage: "quay.io/eclipse/kubernetes-image-puller:next"
 resources:
   requests:
     cpu: "50m"


### PR DESCRIPTION
## Summary
- Derive `KIP_IMAGE` in the ConfigMap template from `image.repository` and `image.tag` instead of a separate `configMap.kipImage` value
- Remove the redundant `configMap.kipImage` from `values.yaml`
- Remove the `configMap.kipImage` row from the Helm values table in the README

## Why

The Helm chart defined the image-puller image in two independent places: `image.repository`/`image.tag` for the Deployment container and `configMap.kipImage` for the `KIP_IMAGE` ConfigMap entry. These must always be the same image — `KIP_IMAGE` controls the `copy-sleep` initContainer that copies the sleep binary from the same image the controller runs. The operator repo already treats these as a single value. Having them separate in the Helm chart created a maintenance burden and a risk of silent drift.

## Test plan
- [x] `helm template` confirms `KIP_IMAGE` matches the Deployment image with default values
- [x] `helm template --set image.repository=... --set image.tag=...` confirms both stay in sync when overridden
- [x] No remaining references to `kipImage` in the Helm chart
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Helm configuration so the image value is now built from the main image repository and tag settings, keeping deployment settings consistent.
* **Documentation**
  * Removed outdated Helm documentation for a configuration option that is no longer used.
* **Chores**
  * Cleaned up default Helm values by removing an unused image setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->