### PR TITLE
fix: pin try-in-web-ide GitHub Action to v1.5.0

### DIFF
--- a/.github/workflows/try-in-web-ide.yaml
+++ b/.github/workflows/try-in-web-ide.yaml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - name: Web IDE Pull Request Check
         id: try-in-web-ide
-        uses: redhat-actions/try-in-web-ide@v1.2
+        uses: redhat-actions/try-in-web-ide@6d64b671fa7f83b770c5dd1d1094559a509d2a50 # v1.5.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Pin `redhat-actions/try-in-web-ide` to SHA digest for v1.5.0 (`6d64b67`)
- Previously referenced unpinned tag `v1.2`

## Test plan
- [x] Workflow file syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the “Try in Web IDE” link generation process to use a newer, pinned integration version, helping keep the experience stable and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->