### PR TITLE
fix: remove hardcoded UID/GID to restore OpenShift SCC compatibility

### DIFF
--- a/e2e/deploy_test.go
+++ b/e2e/deploy_test.go
@@ -143,9 +143,6 @@ func checkPods(t *testing.T, clientset *kubernetes.Clientset) {
 				if initCtx == nil {
 					t.Errorf("InitContainer %s SecurityContext is nil", initContainer.Name)
 				} else {
-					if initCtx.RunAsUser == nil || *initCtx.RunAsUser != 65532 {
-						t.Errorf("InitContainer %s not running as UID 65532: %v", initContainer.Name, initCtx.RunAsUser)
-					}
 					if initCtx.RunAsNonRoot == nil || !*initCtx.RunAsNonRoot {
 						t.Errorf("InitContainer %s RunAsNonRoot is not true", initContainer.Name)
 					}

--- a/utils/clusterutils.go
+++ b/utils/clusterutils.go
@@ -43,12 +43,7 @@ var (
 	bTrue  = true
 	bFalse = false
 
-	// UID/GID 65532 is the standard "nonroot" user in distroless images and
-	// must match the UID created by 'adduser -u 65532 appuser' in build/dockerfiles/Dockerfile.
-	nonRootUID       = int64(65532)
-	nonRootGID       = int64(65532)
-	seccompProfile   = corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}
-	// Sleep binary is ~500KB; 50Mi provides ample headroom for platform variations.
+	seccompProfile     = corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}
 	kipVolumeSizeLimit = resource.MustParse("50Mi")
 
 	// Volume mount to copy the sleep binary into.
@@ -134,7 +129,6 @@ func getDaemonset(deployment *appsv1.Deployment) *appsv1.DaemonSet {
 				},
 				Spec: corev1.PodSpec{
 					SecurityContext: &corev1.PodSecurityContext{
-						FSGroup:        &nonRootGID,
 						SeccompProfile: &seccompProfile,
 					},
 					NodeSelector:                  cfg.NodeSelector,
@@ -148,9 +142,7 @@ func getDaemonset(deployment *appsv1.Deployment) *appsv1.DaemonSet {
 						VolumeMounts:    containerVolumeMounts,
 						Resources:       getContainerResources(cfg),
 						SecurityContext: &corev1.SecurityContext{
-							RunAsNonRoot:             &bTrue,
-							RunAsUser:                &nonRootUID,
-							RunAsGroup:               &nonRootGID,
+							RunAsNonRoot: &bTrue,
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},

--- a/utils/clusterutils_test.go
+++ b/utils/clusterutils_test.go
@@ -52,15 +52,18 @@ func TestGetDaemonsetPodSecurityContext(t *testing.T) {
 	assert.Nil(t, ctx.RunAsNonRoot, "RunAsNonRoot should not be set at pod level")
 	assert.Nil(t, ctx.RunAsUser, "RunAsUser should not be set at pod level")
 	assert.Nil(t, ctx.RunAsGroup, "RunAsGroup should not be set at pod level")
-	assert.Equal(t, int64(65532), *ctx.FSGroup, "FSGroup should be 65532")
+	assert.Nil(t, ctx.FSGroup, "FSGroup should not be set — let the platform assign it")
 	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, ctx.SeccompProfile.Type, "SeccompProfile should be RuntimeDefault")
 
 	initContainer := ds.Spec.Template.Spec.InitContainers[0]
 	initCtx := initContainer.SecurityContext
 	assert.NotNil(t, initCtx, "InitContainer SecurityContext should be set")
 	assert.True(t, *initCtx.RunAsNonRoot, "InitContainer RunAsNonRoot should be true")
-	assert.Equal(t, int64(65532), *initCtx.RunAsUser, "InitContainer RunAsUser should be 65532")
-	assert.Equal(t, int64(65532), *initCtx.RunAsGroup, "InitContainer RunAsGroup should be 65532")
+	assert.Nil(t, initCtx.RunAsUser, "RunAsUser should not be set — let the platform assign it")
+	assert.Nil(t, initCtx.RunAsGroup, "RunAsGroup should not be set — let the platform assign it")
+	assert.True(t, *initCtx.ReadOnlyRootFilesystem, "InitContainer ReadOnlyRootFilesystem should be true")
+	assert.False(t, *initCtx.AllowPrivilegeEscalation, "InitContainer AllowPrivilegeEscalation should be false")
+	assert.Equal(t, []corev1.Capability{"ALL"}, initCtx.Capabilities.Drop, "InitContainer should drop all capabilities")
 }
 
 func TestGetDaemonsetEmptyDirVolume(t *testing.T) {


### PR DESCRIPTION
## Summary

- Removes hardcoded UID 65532 / GID 65532 from the DaemonSet pod and initContainer security contexts introduced in #222
- On OpenShift, the `restricted-v2` SCC requires UIDs/GIDs from the namespace-allocated range — hardcoding 65532 causes pod creation to fail
- Retains all other security hardening: `RunAsNonRoot`, `SeccompProfile`, `Capabilities: Drop ALL`, `ReadOnlyRootFilesystem`, `AllowPrivilegeEscalation: false`, bounded emptyDir

On vanilla Kubernetes the container's Dockerfile `USER` directive (65532) is used automatically. On OpenShift the SCC assigns a UID from the namespace range.

Fixes the error:
```
provider restricted-v2: .spec.securityContext.fsGroup: Invalid value: [65532]: 65532 is not an allowed group
provider restricted-v2: .initContainers[0].runAsUser: Invalid value: 65532: must be in the ranges: [1000660000, 1000669999]
```

## Test plan

- [ ] Unit tests updated and passing (`go test ./utils/`)
- [ ] E2e test updated to remove hardcoded UID assertion
- [ ] Verify DaemonSet pods schedule on OpenShift with `restricted-v2` SCC
- [ ] Verify DaemonSet pods still schedule on vanilla Kubernetes with `restricted` PSA

Signed-off-by: Chris Brown <chribrow@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)