### PR TITLE
ci: add quality gates to PR checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -35,6 +35,14 @@ jobs:
       with:
         go-version-file: go.mod
     -
+      name: Check go mod tidy
+      run: |
+        go mod tidy
+        git diff --exit-code go.mod go.sum
+    -
+      name: Run golangci-lint
+      uses: golangci/golangci-lint-action@d583c34f0599d37dbac4a198b9c83201be380893 # v9
+    -
       name: Run tests
       run: make test
     -

--- a/utils/clusterutils_test.go
+++ b/utils/clusterutils_test.go
@@ -75,8 +75,8 @@ func TestGetDaemonsetEmptyDirVolume(t *testing.T) {
 	volumes := ds.Spec.Template.Spec.Volumes
 	assert.Len(t, volumes, 1, "Should have exactly one volume")
 	assert.Equal(t, "kip", volumes[0].Name)
-	assert.NotNil(t, volumes[0].VolumeSource.EmptyDir, "Volume should be EmptyDir")
-	assert.Equal(t, resource.MustParse("50Mi"), *volumes[0].VolumeSource.EmptyDir.SizeLimit, "SizeLimit should be 50Mi")
+	assert.NotNil(t, volumes[0].EmptyDir, "Volume should be EmptyDir")
+	assert.Equal(t, resource.MustParse("50Mi"), *volumes[0].EmptyDir.SizeLimit, "SizeLimit should be 50Mi")
 }
 
 // This is the only function that does not require a kubernetes client.  The rest of the tests are in ./e2e


### PR DESCRIPTION
## Summary

- Add Dependabot config for Go modules and GitHub Actions (weekly schedule)
- Add `golangci-lint` to the CI test job (SHA-pinned)
- Add `go mod tidy` drift check to catch uncommitted module changes

govulncheck was already present.

## Test plan

- [ ] golangci-lint passes on this PR
- [ ] go mod tidy check passes on this PR
- [ ] Dependabot creates its first PRs after merge

Signed-off-by: Chris Brown <chribrow@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency update checks for Go modules and GitHub Actions on a weekly schedule.
* **Tests**
  * Strengthened CI by verifying dependency files stay clean after tidy runs and by adding lint checks before test and security scans.
  * Updated an existing test assertion to match the current expected volume structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->