### PR TITLE
chore: Revert go version to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/che-incubator/kubernetes-image-puller
 
-go 1.26.5
+go 1.26.4
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version to `1.26.4` in the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->