### PR TITLE
chore: create security context depending on infra

### DIFF
--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestEnvVars(t *testing.T) {
 
-	t.Setenv("IMAGES", "che-theia=quay.io/eclipse/che-theia:nightly")
+	t.Setenv("IMAGES", "che-code=quay.io/che-incubator/che-code:next;base-developer-image=quay.io/devfile/base-developer-image:ubi9-latest")
 	t.Setenv("CACHING_INTERVAL_HOURS", "5")
 
 	type testcase struct {
@@ -27,7 +27,8 @@ func TestEnvVars(t *testing.T) {
 				DaemonsetAnnotations: map[string]string{},
 				Namespace:     "k8s-image-puller",
 				Images: map[string]string{
-					"che-theia": "quay.io/eclipse/che-theia:nightly",
+					"che-code":              "quay.io/che-incubator/che-code:next",
+					"base-developer-image": "quay.io/devfile/base-developer-image:ubi9-latest",
 				},
 				CachingMemRequest: "1Mi",
 				CachingMemLimit:   "5Mi",
@@ -61,7 +62,8 @@ func TestEnvVars(t *testing.T) {
 				},
 				Namespace:     "my-namespace",
 				Images: map[string]string{
-					"che-theia": "quay.io/eclipse/che-theia:nightly",
+					"che-code":              "quay.io/che-incubator/che-code:next",
+					"base-developer-image": "quay.io/devfile/base-developer-image:ubi9-latest",
 				},
 				CachingMemRequest: "1Mi",
 				CachingMemLimit:   "5Mi",

--- a/cfg/envvars_test.go
+++ b/cfg/envvars_test.go
@@ -18,16 +18,15 @@ func TestProcessImagesEnvVar(t *testing.T) {
 	testcases := []testcase{
 		{
 			name:   "one image",
-			images: "che-theia=quay.io/eclipse/che-theia:nightly",
-			want:   map[string]string{"che-theia": "quay.io/eclipse/che-theia:nightly"},
+			images: "che-code=quay.io/che-incubator/che-code:next",
+			want:   map[string]string{"che-code": "quay.io/che-incubator/che-code:next"},
 		},
 		{
-			name:   "three images",
-			images: "image1=my/image1:dev;image2=my/image2:next;image3=my/image3:stage",
+			name:   "two images",
+			images: "che-code=quay.io/che-incubator/che-code:next;base-developer-image=quay.io/devfile/base-developer-image:ubi9-latest",
 			want: map[string]string{
-				"image1": "my/image1:dev",
-				"image2": "my/image2:next",
-				"image3": "my/image3:stage",
+				"che-code":              "quay.io/che-incubator/che-code:next",
+				"base-developer-image": "quay.io/devfile/base-developer-image:ubi9-latest",
 			},
 		},
 	}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -11,9 +11,8 @@ priorityClassName: ""
 configMap:
   name: k8s-image-puller
   images: >
-    java11-maven=quay.io/eclipse/che-java11-maven:nightly;
-    che-theia=quay.io/eclipse/che-theia:next;
-    java-plugin-runner=docker.io/eclipse/che-remote-plugin-runner-java8:latest;
+    che-code=quay.io/che-incubator/che-code:next;
+    base-developer-image=quay.io/devfile/base-developer-image:ubi9-latest;
   cachingIntervalHours: 1
   cachingMemoryRequest: "10Mi"
   cachingMemoryLimit: "20Mi"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -13,7 +13,7 @@ configMap:
   images: >
     java11-maven=quay.io/eclipse/che-java11-maven:nightly;
     che-theia=quay.io/eclipse/che-theia:next;
-    java-plugin-runner=eclipse/che-remote-plugin-runner-java8:latest;
+    java-plugin-runner=docker.io/eclipse/che-remote-plugin-runner-java8:latest;
   cachingIntervalHours: 1
   cachingMemoryRequest: "10Mi"
   cachingMemoryLimit: "20Mi"

--- a/deploy/openshift/configmap.yaml
+++ b/deploy/openshift/configmap.yaml
@@ -29,7 +29,7 @@ parameters:
   value: >
       java11-maven=quay.io/eclipse/che-java11-maven:next;
       che-theia=quay.io/eclipse/che-theia:next;
-      java-plugin-runner=eclipse/che-remote-plugin-runner-java8:latest;
+      java-plugin-runner=docker.io/eclipse/che-remote-plugin-runner-java8:latest;
 - name: DAEMONSET_NAME
   value: "kubernetes-image-puller"
 - name: CACHING_INTERVAL_HOURS

--- a/deploy/openshift/configmap.yaml
+++ b/deploy/openshift/configmap.yaml
@@ -27,9 +27,8 @@ objects:
 parameters:
 - name: IMAGES
   value: >
-      java11-maven=quay.io/eclipse/che-java11-maven:next;
-      che-theia=quay.io/eclipse/che-theia:next;
-      java-plugin-runner=docker.io/eclipse/che-remote-plugin-runner-java8:latest;
+      che-code=quay.io/che-incubator/che-code:next;
+      base-developer-image=quay.io/devfile/base-developer-image:ubi9-latest;
 - name: DAEMONSET_NAME
   value: "kubernetes-image-puller"
 - name: CACHING_INTERVAL_HOURS

--- a/e2e/deploy_test.go
+++ b/e2e/deploy_test.go
@@ -61,9 +61,7 @@ func TestSingleClusterCacheImages(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		{name: "test images", images: "che-theia=quay.io/eclipse/che-theia:next;che-plugin-registry=quay.io/eclipse/che-plugin-registry:next"},
-		{name: "test scratch image", images: "che-machine-exec=quay.io/eclipse/che-machine-exec:next;"},
-		{name: "test volume mount image", images: "volume-mount-image=quay.io/dkwon17/volume-mount:latest"},
+		{name: "test images", images: "che-code=quay.io/che-incubator/che-code:next;base-developer-image=quay.io/devfile/base-developer-image:ubi9-latest"},
 	}
 
 	clientset, err := getClientset(t)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 )
 
 require (
@@ -43,7 +44,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect

--- a/utils/clusterutils.go
+++ b/utils/clusterutils.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -40,9 +41,8 @@ var (
 	propagationPolicy             = metav1.DeletePropagationForeground
 	terminationGracePeriodSeconds = int64(1)
 
-	bTrue  = true
-	bFalse = false
-
+	nonRootUID         = int64(65532)
+	nonRootGID         = int64(65532)
 	seccompProfile     = corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}
 	kipVolumeSizeLimit = resource.MustParse("50Mi")
 
@@ -94,7 +94,23 @@ func getOwnerReferenceFromDeployment(deployment *appsv1.Deployment) metav1.Owner
 	}
 }
 
-func getDaemonset(deployment *appsv1.Deployment) *appsv1.DaemonSet {
+func isOpenShift(clientset *kubernetes.Clientset) bool {
+	apiGroups, err := clientset.Discovery().ServerGroups()
+	if err != nil {
+		log.Printf("Failed to discover API groups, assuming vanilla Kubernetes: %v", err)
+		return false
+	}
+
+	for _, group := range apiGroups.Groups {
+		if group.Name == "route.openshift.io" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getDaemonset(deployment *appsv1.Deployment, openShift bool) *appsv1.DaemonSet {
 	cfg := cfg.GetConfig()
 
 	imgPullSecrets := []corev1.LocalObjectReference{}
@@ -128,9 +144,7 @@ func getDaemonset(deployment *appsv1.Deployment) *appsv1.DaemonSet {
 					Name: "test-po",
 				},
 				Spec: corev1.PodSpec{
-					SecurityContext: &corev1.PodSecurityContext{
-						SeccompProfile: &seccompProfile,
-					},
+					SecurityContext:               podSecurityContext(openShift),
 					NodeSelector:                  cfg.NodeSelector,
 					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 					InitContainers: []corev1.Container{{
@@ -141,14 +155,7 @@ func getDaemonset(deployment *appsv1.Deployment) *appsv1.DaemonSet {
 						Args:            []string{"-c", copySleepCommand},
 						VolumeMounts:    containerVolumeMounts,
 						Resources:       getContainerResources(cfg),
-						SecurityContext: &corev1.SecurityContext{
-							RunAsNonRoot: &bTrue,
-							Capabilities: &corev1.Capabilities{
-								Drop: []corev1.Capability{"ALL"},
-							},
-							ReadOnlyRootFilesystem:   &bTrue,
-							AllowPrivilegeEscalation: &bFalse,
-						},
+						SecurityContext: initContainerSecurityContext(openShift),
 					}},
 					Containers:       getContainers(),
 					ImagePullSecrets: imgPullSecrets,
@@ -161,11 +168,40 @@ func getDaemonset(deployment *appsv1.Deployment) *appsv1.DaemonSet {
 							},
 						},
 					}},
-					Tolerations:      cfg.Tolerations,
+					Tolerations: cfg.Tolerations,
 				},
 			},
 		},
 	}
+}
+
+func podSecurityContext(openShift bool) *corev1.PodSecurityContext {
+	ctx := &corev1.PodSecurityContext{
+		SeccompProfile: &seccompProfile,
+	}
+
+	if !openShift {
+		ctx.FSGroup = &nonRootGID
+	}
+
+	return ctx
+}
+
+func initContainerSecurityContext(openShift bool) *corev1.SecurityContext {
+	ctx := &corev1.SecurityContext{
+		RunAsNonRoot: ptr.To(true),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(false),
+	}
+
+	if !openShift {
+		ctx.RunAsUser = &nonRootUID
+		ctx.RunAsGroup = &nonRootGID
+	}
+	return ctx
 }
 
 // Create the daemonset, using to-be-cached images as init containers. Blocks
@@ -173,7 +209,8 @@ func getDaemonset(deployment *appsv1.Deployment) *appsv1.DaemonSet {
 func createDaemonsetOrDie(clientset *kubernetes.Clientset) {
 	cfg := cfg.GetConfig()
 	thisDeployment := getImagePullerDeployment(clientset)
-	toCreate := getDaemonset(thisDeployment)
+	isOpenShiftInfra := isOpenShift(clientset)
+	toCreate := getDaemonset(thisDeployment, isOpenShiftInfra)
 	dsWatch := watchDaemonset(clientset)
 	defer dsWatch.Stop()
 	watchChan := dsWatch.ResultChan()
@@ -297,8 +334,8 @@ func getContainers() []corev1.Container {
 				Capabilities: &corev1.Capabilities{
 					Drop: []corev1.Capability{"ALL"},
 				},
-				ReadOnlyRootFilesystem:   &bTrue,
-				AllowPrivilegeEscalation: &bFalse,
+				ReadOnlyRootFilesystem:   ptr.To(true),
+				AllowPrivilegeEscalation: ptr.To(false),
 			},
 		}
 		idx++

--- a/utils/clusterutils_test.go
+++ b/utils/clusterutils_test.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -33,34 +34,59 @@ var (
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
-		ReadOnlyRootFilesystem:   &bTrue,
-		AllowPrivilegeEscalation: &bFalse,
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(false),
 	}
 )
 
-func TestGetDaemonsetPodSecurityContext(t *testing.T) {
+func TestGetDaemonsetPodSecurityContextKubernetes(t *testing.T) {
 	t.Setenv("IMAGES", "test=quay.io/test:latest")
 	t.Setenv("CACHING_INTERVAL_HOURS", "1")
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", UID: "test-uid"},
 	}
-	ds := getDaemonset(deployment)
+	ds := getDaemonset(deployment, false)
 
 	ctx := ds.Spec.Template.Spec.SecurityContext
 	assert.NotNil(t, ctx, "PodSecurityContext should be set")
 	assert.Nil(t, ctx.RunAsNonRoot, "RunAsNonRoot should not be set at pod level")
 	assert.Nil(t, ctx.RunAsUser, "RunAsUser should not be set at pod level")
 	assert.Nil(t, ctx.RunAsGroup, "RunAsGroup should not be set at pod level")
-	assert.Nil(t, ctx.FSGroup, "FSGroup should not be set — let the platform assign it")
+	assert.Equal(t, int64(65532), *ctx.FSGroup, "FSGroup should be 65532")
 	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, ctx.SeccompProfile.Type, "SeccompProfile should be RuntimeDefault")
 
 	initContainer := ds.Spec.Template.Spec.InitContainers[0]
 	initCtx := initContainer.SecurityContext
 	assert.NotNil(t, initCtx, "InitContainer SecurityContext should be set")
 	assert.True(t, *initCtx.RunAsNonRoot, "InitContainer RunAsNonRoot should be true")
-	assert.Nil(t, initCtx.RunAsUser, "RunAsUser should not be set — let the platform assign it")
-	assert.Nil(t, initCtx.RunAsGroup, "RunAsGroup should not be set — let the platform assign it")
+	assert.Equal(t, int64(65532), *initCtx.RunAsUser, "InitContainer RunAsUser should be 65532")
+	assert.Equal(t, int64(65532), *initCtx.RunAsGroup, "InitContainer RunAsGroup should be 65532")
+	assert.True(t, *initCtx.ReadOnlyRootFilesystem, "InitContainer ReadOnlyRootFilesystem should be true")
+	assert.False(t, *initCtx.AllowPrivilegeEscalation, "InitContainer AllowPrivilegeEscalation should be false")
+	assert.Equal(t, []corev1.Capability{"ALL"}, initCtx.Capabilities.Drop, "InitContainer should drop all capabilities")
+}
+
+func TestGetDaemonsetPodSecurityContextOpenShift(t *testing.T) {
+	t.Setenv("IMAGES", "test=quay.io/test:latest")
+	t.Setenv("CACHING_INTERVAL_HOURS", "1")
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", UID: "test-uid"},
+	}
+	ds := getDaemonset(deployment, true)
+
+	ctx := ds.Spec.Template.Spec.SecurityContext
+	assert.NotNil(t, ctx, "PodSecurityContext should be set")
+	assert.Nil(t, ctx.FSGroup, "FSGroup should not be set on OpenShift")
+	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, ctx.SeccompProfile.Type, "SeccompProfile should be RuntimeDefault")
+
+	initContainer := ds.Spec.Template.Spec.InitContainers[0]
+	initCtx := initContainer.SecurityContext
+	assert.NotNil(t, initCtx, "InitContainer SecurityContext should be set")
+	assert.True(t, *initCtx.RunAsNonRoot, "InitContainer RunAsNonRoot should be true")
+	assert.Nil(t, initCtx.RunAsUser, "RunAsUser should not be set on OpenShift")
+	assert.Nil(t, initCtx.RunAsGroup, "RunAsGroup should not be set on OpenShift")
 	assert.True(t, *initCtx.ReadOnlyRootFilesystem, "InitContainer ReadOnlyRootFilesystem should be true")
 	assert.False(t, *initCtx.AllowPrivilegeEscalation, "InitContainer AllowPrivilegeEscalation should be false")
 	assert.Equal(t, []corev1.Capability{"ALL"}, initCtx.Capabilities.Drop, "InitContainer should drop all capabilities")
@@ -73,7 +99,7 @@ func TestGetDaemonsetEmptyDirVolume(t *testing.T) {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", UID: "test-uid"},
 	}
-	ds := getDaemonset(deployment)
+	ds := getDaemonset(deployment, false)
 
 	volumes := ds.Spec.Template.Spec.Volumes
 	assert.Len(t, volumes, 1, "Should have exactly one volume")

--- a/utils/clusterutils_test.go
+++ b/utils/clusterutils_test.go
@@ -40,7 +40,7 @@ var (
 )
 
 func TestGetDaemonsetPodSecurityContextKubernetes(t *testing.T) {
-	t.Setenv("IMAGES", "test=quay.io/test:latest")
+	t.Setenv("IMAGES", "che-code=quay.io/che-incubator/che-code:next;base-developer-image=quay.io/devfile/base-developer-image:ubi9-latest")
 	t.Setenv("CACHING_INTERVAL_HOURS", "1")
 
 	deployment := &appsv1.Deployment{
@@ -68,7 +68,7 @@ func TestGetDaemonsetPodSecurityContextKubernetes(t *testing.T) {
 }
 
 func TestGetDaemonsetPodSecurityContextOpenShift(t *testing.T) {
-	t.Setenv("IMAGES", "test=quay.io/test:latest")
+	t.Setenv("IMAGES", "che-code=quay.io/che-incubator/che-code:next;base-developer-image=quay.io/devfile/base-developer-image:ubi9-latest")
 	t.Setenv("CACHING_INTERVAL_HOURS", "1")
 
 	deployment := &appsv1.Deployment{
@@ -93,7 +93,7 @@ func TestGetDaemonsetPodSecurityContextOpenShift(t *testing.T) {
 }
 
 func TestGetDaemonsetEmptyDirVolume(t *testing.T) {
-	t.Setenv("IMAGES", "test=quay.io/test:latest")
+	t.Setenv("IMAGES", "che-code=quay.io/che-incubator/che-code:next;base-developer-image=quay.io/devfile/base-developer-image:ubi9-latest")
 	t.Setenv("CACHING_INTERVAL_HOURS", "1")
 
 	deployment := &appsv1.Deployment{
@@ -118,10 +118,23 @@ func TestGetContainers(t *testing.T) {
 
 	testcases := []testcase{
 		{
+			name: "one container",
+			want: []corev1.Container{{
+				Name:            "che-code",
+				Image:           "quay.io/che-incubator/che-code:next",
+				Command:         defaultCommand,
+				Args:            defaultArgs,
+				ImagePullPolicy: corev1.PullAlways,
+				Resources:       defaultResourceRequirements,
+				VolumeMounts:    defaultVolumeMounts,
+				SecurityContext: &defaultSecurityContext,
+			}},
+			images: "che-code=quay.io/che-incubator/che-code:next",
+		}, {
 			name: "two containers",
 			want: []corev1.Container{{
-				Name:            "che-theia",
-				Image:           "eclipse/che-theia:nightly",
+				Name:            "che-code",
+				Image:           "quay.io/che-incubator/che-code:next",
 				Command:         defaultCommand,
 				Args:            defaultArgs,
 				ImagePullPolicy: corev1.PullAlways,
@@ -129,8 +142,8 @@ func TestGetContainers(t *testing.T) {
 				VolumeMounts:    defaultVolumeMounts,
 				SecurityContext: &defaultSecurityContext,
 			}, {
-				Name:            "che-plugin-registry",
-				Image:           "quay.io/eclipse/che-plugin-registry:nightly",
+				Name:            "base-developer-image",
+				Image:           "quay.io/devfile/base-developer-image:ubi9-latest",
 				Command:         defaultCommand,
 				Args:            defaultArgs,
 				ImagePullPolicy: corev1.PullAlways,
@@ -138,47 +151,7 @@ func TestGetContainers(t *testing.T) {
 				VolumeMounts:    defaultVolumeMounts,
 				SecurityContext: &defaultSecurityContext,
 			}},
-			images: "che-theia=eclipse/che-theia:nightly;che-plugin-registry=quay.io/eclipse/che-plugin-registry:nightly",
-		}, {
-			name: "four containers",
-			want: []corev1.Container{{
-				Name:            "che-sidecar-java",
-				Image:           "quay.io/eclipse/che-sidecar-java:nightly",
-				Command:         defaultCommand,
-				Args:            defaultArgs,
-				ImagePullPolicy: corev1.PullAlways,
-				Resources:       defaultResourceRequirements,
-				VolumeMounts:    defaultVolumeMounts,
-				SecurityContext: &defaultSecurityContext,
-			}, {
-				Name:            "che-plugin-registry",
-				Image:           "quay.io/eclipse/che-plugin-registry:nightly",
-				Command:         defaultCommand,
-				Args:            defaultArgs,
-				ImagePullPolicy: corev1.PullAlways,
-				Resources:       defaultResourceRequirements,
-				VolumeMounts:    defaultVolumeMounts,
-				SecurityContext: &defaultSecurityContext,
-			}, {
-				Name:            "che-devfile-registry",
-				Image:           "quay.io/eclipse/che-devfile-registry:nightly",
-				Command:         defaultCommand,
-				Args:            defaultArgs,
-				ImagePullPolicy: corev1.PullAlways,
-				Resources:       defaultResourceRequirements,
-				VolumeMounts:    defaultVolumeMounts,
-				SecurityContext: &defaultSecurityContext,
-			}, {
-				Name:            "che-theia",
-				Image:           "quay.io/eclipse/che-theia:nightly",
-				Command:         defaultCommand,
-				Args:            defaultArgs,
-				ImagePullPolicy: corev1.PullAlways,
-				Resources:       defaultResourceRequirements,
-				VolumeMounts:    defaultVolumeMounts,
-				SecurityContext: &defaultSecurityContext,
-			}},
-			images: "che-sidecar-java=quay.io/eclipse/che-sidecar-java:nightly;che-plugin-registry=quay.io/eclipse/che-plugin-registry:nightly;che-devfile-registry=quay.io/eclipse/che-devfile-registry:nightly;che-theia=quay.io/eclipse/che-theia:nightly",
+			images: "che-code=quay.io/che-incubator/che-code:next;base-developer-image=quay.io/devfile/base-developer-image:ubi9-latest",
 		},
 	}
 	for _, c := range testcases {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image-puller deployment compatibility across Kubernetes and OpenShift by applying platform-specific security context settings.
  * Updated Java plugin runner image references to use the explicit Docker registry address for consistent image pulling.
* **Tests**
  * Enhanced security-context validation with separate Kubernetes and OpenShift test cases to ensure correct non-root behavior and seccomp handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->