### PR TITLE
feat: publish Helm chart to quay.io OCI registry

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2026 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: helm-publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    if: github.repository == 'che-incubator/kubernetes-image-puller'
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+    -
+      name: Clone source code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        fetch-depth: 1
+        persist-credentials: false
+    -
+      name: Set up Helm
+      uses: azure/setup-helm@59b1c81c6280f5abebb1fb1bc585696daa7dfb42 # v5
+    -
+      name: Lint chart
+      run: helm lint deploy/helm/
+    -
+      name: Login to quay.io
+      run: |
+        set -eo pipefail
+        echo "${{ secrets.QUAY_PASSWORD }}" | helm registry login quay.io --username "${{ secrets.QUAY_USERNAME }}" --password-stdin
+    -
+      name: Package and push chart
+      run: |
+        set -eo pipefail
+        CHART_PKG=$(helm package deploy/helm/ | awk '{print $NF}')
+        helm push "$CHART_PKG" oci://quay.io/eclipse

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -42,6 +42,31 @@ jobs:
       name: Run tests
       run: make test
 
+  helm-lint:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+    -
+      name: Clone source code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    -
+      name: Set up Helm
+      uses: azure/setup-helm@59b1c81c6280f5abebb1fb1bc585696daa7dfb42 # v5
+    -
+      name: Lint chart
+      run: helm lint deploy/helm/
+    -
+      name: Install kubeconform
+      run: |
+        curl -sSL https://github.com/yannh/kubeconform/releases/download/v0.8.0/kubeconform-linux-amd64.tar.gz | tar xz
+        sudo mv kubeconform /usr/local/bin/
+    -
+      name: Validate template rendering
+      run: helm template test deploy/helm/ | kubeconform -strict -summary
+
   build:
     needs: test
     runs-on: ubuntu-22.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,9 @@ The codebase uses `log.Fatalf()` for unrecoverable errors (failed client creatio
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `next-build.yml` | Push to `main`, pull requests, manual | Runs test job (unit tests + govulncheck), then builds and pushes container image to quay.io |
+| `release-build.yml` | Push of `v*` tag | Runs tests, builds and pushes release container image to quay.io |
+| `helm-publish.yml` | Push of `v*` tag | Lints, packages, and pushes the Helm chart to `oci://quay.io/eclipse` |
+| `pr-check.yml` | Pull requests to `main` | Runs tests, Helm lint/template validation, and a test build (no push) |
 
 The test job uses `go-version-file: go.mod` to install the Go version specified in the module. When bumping the Go version in `go.mod`, CI automatically picks up the new version.
 
@@ -132,6 +135,20 @@ The test job uses `go-version-file: go.mod` to install the Go version specified 
 - Checkout steps should use `persist-credentials: false`
 - Workflow permissions should be explicitly scoped (e.g. `contents: read`)
 - govulncheck should be pinned to a specific version, not `@latest`
+
+### Helm Chart
+
+The Helm chart lives in `deploy/helm/` and is published to `oci://quay.io/eclipse/kubernetes-image-puller` on each release. The chart uses `apiVersion: v2` and its version is kept in sync with the application version by `make-release.sh`.
+
+```bash
+helm lint deploy/helm/                  # Validate chart
+helm template test deploy/helm/         # Render templates locally
+```
+
+When modifying the Helm chart:
+- Run `helm lint` and `helm template` before pushing — CI checks both via the `helm-lint` job in `pr-check.yml`
+- Keep Helm templates and OpenShift templates in sync — changes to one should be reflected in the other
+- The chart version in `Chart.yaml` is updated by `make-release.sh` — do not bump it manually
 
 ## Contribution Workflow
 

--- a/README.md
+++ b/README.md
@@ -88,11 +88,23 @@ The following values can be set:
 
 ### Installation - Helm
 
-`kubectl create namespace k8s-image-puller`
+The Helm chart is published as an OCI artifact to quay.io on each release.
 
-`helm install kubernetes-image-puller -n k8s-image-puller deploy/helm`
+Install from the OCI registry (recommended):
 
-To set values, change `deploy/helm/values.yaml` or use `--set property.name=value`
+```shell
+kubectl create namespace k8s-image-puller
+helm install kubernetes-image-puller -n k8s-image-puller oci://quay.io/eclipse/kubernetes-image-puller --version <version>
+```
+
+Or install from a local checkout:
+
+```shell
+kubectl create namespace k8s-image-puller
+helm install kubernetes-image-puller -n k8s-image-puller deploy/helm
+```
+
+To set values, use `--set property.name=value` or provide a custom values file with `-f values.yaml`.
 
 ### Installation - OpenShift
 
@@ -211,7 +223,7 @@ The release process consists of the following steps:
    ```
    This creates a `<version>-release` branch.
 
-2. Wait until the [build-release](https://github.com/che-incubator/kubernetes-image-puller/actions/workflows/release-build.yml) workflow completes successfully.
+2. Wait until the [build-release](https://github.com/che-incubator/kubernetes-image-puller/actions/workflows/release-build.yml) and [helm-publish](https://github.com/che-incubator/kubernetes-image-puller/actions/workflows/helm-publish.yml) workflows complete successfully.
 
 3. Check out the release branch and test the image puller on both Kubernetes and OpenShift by deploying with Helm:
    ```shell

--- a/deploy/helm/.helmignore
+++ b/deploy/helm/.helmignore
@@ -1,0 +1,7 @@
+.git/
+.gitignore
+.DS_Store
+*.swp
+*.bak
+*.tmp
+*.orig

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,4 +1,17 @@
-apiVersion: v1
+apiVersion: v2
 name: kubernetes-image-puller
-version: 1.0.0
-description: The kubernetes image puller downloads che images ahead of time for faster workspace startup
+version: 1.1.2
+appVersion: "next"
+type: application
+description: Pre-pulls container images onto cluster nodes for faster pod startup
+home: https://github.com/che-incubator/kubernetes-image-puller
+sources:
+  - https://github.com/che-incubator/kubernetes-image-puller
+keywords:
+  - kubernetes
+  - image-puller
+  - caching
+  - daemonset
+maintainers:
+  - name: che-incubator
+    url: https://github.com/che-incubator

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -1,0 +1,13 @@
+kubernetes-image-puller has been deployed.
+
+  Deployment: {{ .Values.deploymentName }}
+  Namespace:  {{ .Release.Namespace }}
+
+Check the status:
+
+  kubectl get deployment {{ .Values.deploymentName }} -n {{ .Release.Namespace }}
+
+The image puller controller creates a DaemonSet to cache the configured images
+on every node after startup - it may take a moment to appear. View the DaemonSet:
+
+  kubectl get daemonset -n {{ .Release.Namespace }}

--- a/deploy/helm/templates/app.yaml
+++ b/deploy/helm/templates/app.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ .Values.deploymentName }}
   {{- with .Values.deploymentAnnotations }}
   annotations:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   replicas: 1
@@ -37,15 +37,15 @@ spec:
       {{- if .Values.containerSecurityContext }}
         securityContext: {{ toYaml .Values.containerSecurityContext | nindent 10 }}
       {{- end }}
-      {{- if .Values.tolerations }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- end }}
-      {{- if .Values.nodeSelector }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
-      priorityClassName: {{ .Values.priorityClassName }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}

--- a/deploy/openshift/app.yaml
+++ b/deploy/openshift/app.yaml
@@ -42,6 +42,8 @@ objects:
               cpu: ${DEPLOYMENT_CPU_LIMIT}
               memory: ${DEPLOYMENT_MEMORY_LIMIT}
         serviceAccountName: ${SERVICEACCOUNT_NAME}
+        # Always rendered (OpenShift templates lack conditionals); empty string is a no-op.
+        priorityClassName: ${PRIORITY_CLASS_NAME}
 parameters:
 - name: DEPLOYMENT_NAME
   value: kubernetes-image-puller
@@ -51,6 +53,8 @@ parameters:
   value: quay.io/eclipse/kubernetes-image-puller
 - name: IMAGE_TAG
   value: next
+- name: PRIORITY_CLASS_NAME
+  value: ""
 - name: DEPLOYMENT_CPU_REQUEST
   value: "50m"
 - name: DEPLOYMENT_MEMORY_REQUEST

--- a/make-release.sh
+++ b/make-release.sh
@@ -43,8 +43,10 @@ sed -i "s/IMAGE_TAG=next/IMAGE_TAG=${VERSION}/" "${SCRIPT_DIR}/Makefile"
 # Go default image constant
 sed -i "s|kubernetes-image-puller:next|kubernetes-image-puller:${VERSION}|" "${SCRIPT_DIR}/cfg/envvars.go"
 
-# Helm chart values
+# Helm chart values and Chart.yaml
 sed -i "s/  tag: next/  tag: ${VERSION}/" "${SCRIPT_DIR}/deploy/helm/values.yaml"
+sed -i "s/^version: .*/version: ${VERSION}/" "${SCRIPT_DIR}/deploy/helm/Chart.yaml"
+sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" "${SCRIPT_DIR}/deploy/helm/Chart.yaml"
 
 # OpenShift app template
 sed -i "s/  value: next/  value: ${VERSION}/" "${SCRIPT_DIR}/deploy/openshift/app.yaml"
@@ -55,6 +57,7 @@ sed -i "s|kubernetes-image-puller:next|kubernetes-image-puller:${VERSION}|" "${S
 git add \
   "${SCRIPT_DIR}/Makefile" \
   "${SCRIPT_DIR}/cfg/envvars.go" \
+  "${SCRIPT_DIR}/deploy/helm/Chart.yaml" \
   "${SCRIPT_DIR}/deploy/helm/values.yaml" \
   "${SCRIPT_DIR}/deploy/openshift/app.yaml" \
   "${SCRIPT_DIR}/deploy/openshift/configmap.yaml"


### PR DESCRIPTION
## Summary

Fixes the Helm chart and adds CI to publish it as an OCI artifact to `oci://quay.io/eclipse/kubernetes-image-puller`, closing #161.

- **Chart fixes**: upgrade `Chart.yaml` to `apiVersion: v2` with metadata; fix template bugs (annotations indentation, nodeSelector `nindent`, `priorityClassName` conditional, redundant `if`/`with` on tolerations); add `.helmignore` and `NOTES.txt`
- **New workflow**: `helm-publish.yml` triggered on `v*` tags — lints, packages, and pushes the chart to quay.io using existing `QUAY_USERNAME`/`QUAY_PASSWORD` secrets
- **CI**: add `helm-lint` job to `pr-check.yml` (runs `helm lint` and `helm template`)
- **Release script**: `make-release.sh` now bumps `Chart.yaml` version and appVersion alongside other files

### Installation after this change

```shell
helm install kubernetes-image-puller -n k8s-image-puller \
  oci://quay.io/eclipse/kubernetes-image-puller --version <version>
```

## Test plan

- [x] `helm lint deploy/helm/` passes
- [x] `helm template test deploy/helm/` renders correctly with default values
- [x] `helm template` with non-default values (annotations, nodeSelector, tolerations, priorityClassName) renders correctly
- [x] `helm package deploy/helm/` produces a valid `.tgz`
- [x] Workflow YAML validates
- [ ] Verify `helm-publish.yml` runs successfully on a `v*` tag push (requires merge + release)

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm chart is published as an OCI artifact on each versioned release, with dedicated publish and release checks in CI.
  * Added/updated Helm install documentation (OCI recommended, or local checkout).
  * Helm post-install notes now include verification `kubectl` commands (Deployment + DaemonSet).
  * Added `priorityClassName` support for both the Helm chart and OpenShift template.
* **Bug Fixes**
  * Improved Helm rendering for optional fields, annotations, and indentation/whitespace consistency.
* **Documentation**
  * Expanded CI/Helm chart release guidance and updated release flow to wait for both build and Helm publish checks.
* **Chores**
  * Added Helm chart packaging ignores and migrated chart metadata to Helm v2; release script now syncs chart versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->